### PR TITLE
Update gui.py

### DIFF
--- a/initial_setup/gui/gui.py
+++ b/initial_setup/gui/gui.py
@@ -23,7 +23,8 @@ class InitialSetupGraphicalUserInterface(GraphicalUserInterface):
     def __init__(self, storage, payload, instclass):
         GraphicalUserInterface.__init__(self, storage, payload, instclass,
                                         product_title, is_final,
-                                        quitDialog = InitialSetupQuitDialog)
+                                        quitDialog = InitialSetupQuitDialog,
+                                        fullscreen=True)
 
     def _list_hubs(self):
         return [InitialSetupMainHub]


### PR DESCRIPTION
In RHEL 7.2, when the initial setup is running during first boot, the header bar is seen with title named as  __main__.py. This patch makes the initial setup to run in full screen so that the title and the header bar are hidden.