### PR TITLE
Make Initial Setup to run in fullscreen mode. RHBZ #1267203

### DIFF
--- a/initial_setup/gui/gui.py
+++ b/initial_setup/gui/gui.py
@@ -23,7 +23,8 @@ class InitialSetupGraphicalUserInterface(GraphicalUserInterface):
     def __init__(self, storage, payload, instclass):
         GraphicalUserInterface.__init__(self, storage, payload, instclass,
                                         product_title, is_final,
-                                        quitDialog = InitialSetupQuitDialog)
+                                        quitDialog = InitialSetupQuitDialog, 
+					 fullscreen = True)
 
     def _list_hubs(self):
         return [InitialSetupMainHub]


### PR DESCRIPTION
In RHEL 7.2, the initial setup is started in maximized mode with
header bar visible with title "__main__.py" which is not expected.
This patch makes initial-setup to start in fullscreen mode which
hides header bar. This patch solves bug #1267203.