### PR TITLE
Add a systemd generator that automatically launches IS if trigger file is found

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -97,6 +97,7 @@ make install-po-files
 %exclude %{python_sitelib}/initial_setup/gui
 %{_unitdir}/initial-setup-text.service
 %{_unitdir}/initial-setup.service
+%{_prefix}/lib/systemd/system-generators/initial-setup-generator
 %{_libexecdir}/%{name}/run-initial-setup
 %{_libexecdir}/%{name}/firstboot-windowmanager
 %{_libexecdir}/%{name}/initial-setup-text

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -20,7 +20,7 @@ class InitialSetupError(Exception):
 
 INPUT_KICKSTART_PATH = "/root/anaconda-ks.cfg"
 OUTPUT_KICKSTART_PATH = "/root/initial-setup-ks.cfg"
-RECONFIG_FILE = "/etc/reconfigSys"
+RECONFIG_FILES = ["/etc/reconfigSys", "/.unconfigured"]
 
 SUPPORTED_KICKSTART_COMMANDS = ["user",
                                 "eula",
@@ -37,8 +37,6 @@ SUPPORTED_KICKSTART_COMMANDS = ["user",
 iutil.setSysroot("/")
 
 signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-external_reconfig = os.path.exists(RECONFIG_FILE)
 
 # setup logging
 log = logging.getLogger("initial-setup")
@@ -70,7 +68,17 @@ class InitialSetup(object):
         else:
             log.debug("running in TUI mode")
 
-        if external_reconfig:
+        self._external_reconfig = False
+
+        # check if the reconfig mode should be enabled
+        # by checking if at least one of the reconfig
+        # files exist
+        for reconfig_file in RECONFIG_FILES:
+            if os.path.exists(reconfig_file):
+                self.external_reconfig = True
+                log.debug("reconfig trigger file found: %s", reconfig_file) 
+
+        if self.external_reconfig:
             log.debug("running in externally triggered reconfig mode")
 
         if self.gui_mode:
@@ -108,6 +116,21 @@ class InitialSetup(object):
         log.debug("initializing network logging")
         from pyanaconda.network import setup_ifcfg_log
         setup_ifcfg_log()
+
+    @property
+    def external_reconfig(self):
+        """External reconfig status.
+
+        Reports if external (eq. not triggered by kickstart) has been enabled.
+
+        :returns: True if external reconfig mode has been enabled, else False.
+        :rtype: bool
+        """
+        return self._external_reconfig
+
+    @external_reconfig.setter
+    def external_reconfig(self, value):
+        self._external_reconfig = value
 
     @property
     def gui_mode_id(self):
@@ -159,7 +182,7 @@ class InitialSetup(object):
             log.critical("Initial Setup startup failed due to invalid kickstart file")
             raise InitialSetupError
 
-        if external_reconfig:
+        if self.external_reconfig:
             # set the reconfig flag in kickstart so that
             # relevant spokes show up
             self.data.firstboot.firstboot = FIRSTBOOT_RECONFIG
@@ -208,10 +231,10 @@ class InitialSetup(object):
         log.info("executing addons")
         self.data.addons.execute(None, self.data, None, u)
 
-        if external_reconfig:
-            # prevent the reconfig flag from being written out,
-            # to prevent the reconfig mode from being enabled
-            # without the /etc/reconfigSys file being present
+        if self.external_reconfig:
+            # prevent the reconfig flag from being written out
+            # to kickstart if neither /etc/reconfigSys or /.unconfigured
+            # are present
             self.data.firstboot.firstboot = None
 
         # Write the kickstart data to file
@@ -220,12 +243,13 @@ class InitialSetup(object):
             f.write(str(self.data))
         log.info("finished writing the Initial Setup kickstart file")
 
-        # Remove the reconfig file, if any - otherwise the reconfig mode
-        # would start again next time the Initial Setup service is enabled
-        if external_reconfig and os.path.exists(RECONFIG_FILE):
-            log.debug("removing the reconfig file")
-            os.remove(RECONFIG_FILE)
-            log.debug("the reconfig file has been removed")
+        # Remove the reconfig files, if any - otherwise the reconfig mode
+        # would start again next time the Initial Setup service is enabled.
+        if self.external_reconfig:
+            for reconfig_file in RECONFIG_FILES:
+                if os.path.exists(reconfig_file):
+                    log.debug("removing reconfig trigger file: %s" % reconfig_file)
+                    os.remove(reconfig_file)
 
     def run(self):
         """Run Initial setup

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -137,7 +137,7 @@ class InitialSetup(object):
         """String id of the current GUI mode
 
         :returns: "gui" if gui_mode is True, "tui" otherwise
-        :rtype str:
+        :rtype: str
         """
         if self.gui_mode:
             return "gui"
@@ -201,6 +201,8 @@ class InitialSetup(object):
         # Do not execute sections that were part of the original
         # anaconda kickstart file (== have .seen flag set)
 
+        log.info("applying changes")
+
         sections = [self.data.keyboard, self.data.lang, self.data.timezone]
 
         # data.selinux
@@ -251,12 +253,15 @@ class InitialSetup(object):
                     log.debug("removing reconfig trigger file: %s" % reconfig_file)
                     os.remove(reconfig_file)
 
+        # and we are done with applying changes
+        log.info("all changes have been applied")
+
     def run(self):
         """Run Initial setup
 
         GUI will be used when the gui_mode property is True (TUI mode is the default).
 
-        :returns: True if the IS run was successfull, False if it failed
+        :returns: True if the IS run was successful, False if it failed
         :rtype: bool
         """
 
@@ -292,7 +297,7 @@ class InitialSetup(object):
             log.debug("initializing TUI")
             ui = initial_setup.tui.InitialSetupTextUserInterface(None, None, None)
 
-        # Pass the data object to user inteface
+        # Pass the data object to user interface
         log.debug("setting up the UI")
         ui.setup(self.data)
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ def read(fname):
 
 
 data_files = [('/usr/lib/systemd/system', glob('systemd/*.service')),
+              ('/lib/systemd/system-generators', 'systemd/initial-setup-generator'),
               ('/usr/libexec/initial-setup/',
               ["scripts/run-initial-setup", "scripts/firstboot-windowmanager",
                "scripts/initial-setup-text", "scripts/initial-setup-graphical",

--- a/systemd/initial-setup-generator
+++ b/systemd/initial-setup-generator
@@ -1,0 +1,26 @@
+#!/bin/bash
+### uncomment the following two lines to enable debugging ###
+#[ -w /dev/kmsg ] && exec 30>/dev/kmsg && BASH_XTRACEFD=30
+#set -x
+
+[ ! -e /.unconfigured ] && exit 0
+
+if [ $# -ne 3 ] ; then
+    echo "illegal number of parameters"
+    exit 1
+fi
+
+destdir=$1
+unitdir="/usr/lib/systemd/system"
+
+if [ -e "${unitdir}/initial-setup.service" ] ; then
+    unitfile="initial-setup.service"
+else
+    echo "the inital-setup.service is missing"
+    exit 1
+fi
+
+mkdir -p "${destdir}/default.target.wants"
+ln -s "${unitdir}/${unitfile}" "${destdir}/default.target.wants/${unitfile}"
+
+exit 0


### PR DESCRIPTION
The first patch adds a generator & related IS-side machinery to enable IS when the /.unconfigured trigger file is found. The machinery takes care of enabling IS in reconfig mode and then for cleaning up once done.

The second patch is just some cleanups and logging improvements I did when working on the first patch.