### PR TITLE
Adapt to addon execute() signature change

### DIFF
--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -206,7 +206,7 @@ class InitialSetup(object):
 
         # Configure all addons
         log.info("executing addons")
-        self.data.addons.execute(None, self.data, None, u)
+        self.data.addons.execute(None, self.data, None, u, None)
 
         if external_reconfig:
             # prevent the reconfig flag from being written out,


### PR DESCRIPTION
Fill in the payload field when calling the execute() method on addons
to conform to the new function signature.

Related: rhbz#1288636