### PR TITLE
Use the environs flag when setting the environment

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 21.48.22.36
+%define anacondaver 21.48.22.75
 
 License: GPLv2+
 Group: System Environment/Base

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -14,6 +14,8 @@ from initial_setup import initial_setup_log
 from pyanaconda import iutil
 from pykickstart.constants import FIRSTBOOT_RECONFIG
 from pyanaconda.localization import setup_locale_environment, setup_locale
+from pyanaconda.constants import FIRSTBOOT_ENVIRON
+from pyanaconda.flags import flags
 
 class InitialSetupError(Exception):
     pass
@@ -32,6 +34,9 @@ SUPPORTED_KICKSTART_COMMANDS = ["user",
                                 "logging",
                                 "selinux",
                                 "firewall"]
+
+# set the environment so that spokes can behave accordingly
+flags.environs = [FIRSTBOOT_ENVIRON]
 
 # set root to "/", we are now in the installed system
 iutil.setSysroot("/")

--- a/initial_setup/gui/hubs/initial_setup_hub.py
+++ b/initial_setup/gui/hubs/initial_setup_hub.py
@@ -1,4 +1,3 @@
-from pyanaconda.constants import FIRSTBOOT_ENVIRON
 from pyanaconda.ui.gui.hubs import Hub
 from pyanaconda.ui.gui.spokes import NormalSpoke as GUI_spoke_class
 from initial_setup import product
@@ -16,7 +15,6 @@ class InitialSetupMainHub(Hub):
 
     def __init__(self, *args):
         Hub.__init__(self, *args)
-        self._environs = [FIRSTBOOT_ENVIRON]
 
     def _collectCategoriesAndSpokes(self):
         return common.collectCategoriesAndSpokes(self, GUI_spoke_class)

--- a/initial_setup/tui/hubs/initial_setup_hub.py
+++ b/initial_setup/tui/hubs/initial_setup_hub.py
@@ -1,4 +1,3 @@
-from pyanaconda.constants import FIRSTBOOT_ENVIRON
 from pyanaconda.ui.tui.hubs import TUIHub
 from pyanaconda.ui.tui.spokes import NormalSpoke as TUI_spoke_class
 from initial_setup import product
@@ -22,7 +21,6 @@ class InitialSetupMainHub(TUIHub):
 
     def __init__(self, *args):
         TUIHub.__init__(self, *args)
-        self._environs = [FIRSTBOOT_ENVIRON]
 
     def _collectCategoriesAndSpokes(self):
         return common.collectCategoriesAndSpokes(self, TUI_spoke_class)


### PR DESCRIPTION
The _environs Hub property has been replaced by the environs flag.

Related: rhbz#1270354