### PR TITLE
Add a systemd generator that automatically launches IS if trigger file is found

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -97,6 +97,7 @@ make install-po-files
 %exclude %{python_sitelib}/initial_setup/gui
 %{_unitdir}/initial-setup-text.service
 %{_unitdir}/initial-setup.service
+%{_unitdir}/initial-setup-reconfiguration.service
 %{_libexecdir}/%{name}/run-initial-setup
 %{_libexecdir}/%{name}/firstboot-windowmanager
 %{_libexecdir}/%{name}/initial-setup-text

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -29,7 +29,7 @@ class InitialSetupError(Exception):
 
 INPUT_KICKSTART_PATH = "/root/anaconda-ks.cfg"
 OUTPUT_KICKSTART_PATH = "/root/initial-setup-ks.cfg"
-RECONFIG_FILE = "/etc/reconfigSys"
+RECONFIG_FILES = ["/etc/reconfigSys", "/.unconfigured"]
 
 SUPPORTED_KICKSTART_COMMANDS = ["user",
                                 "eula",
@@ -46,8 +46,6 @@ SUPPORTED_KICKSTART_COMMANDS = ["user",
 iutil.setSysroot("/")
 
 signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-external_reconfig = os.path.exists(RECONFIG_FILE)
 
 # setup logging
 log = logging.getLogger("initial-setup")
@@ -79,7 +77,17 @@ class InitialSetup(object):
         else:
             log.debug("running in TUI mode")
 
-        if external_reconfig:
+        self._external_reconfig = False
+
+        # check if the reconfig mode should be enabled
+        # by checking if at least one of the reconfig
+        # files exist
+        for reconfig_file in RECONFIG_FILES:
+            if os.path.exists(reconfig_file):
+                self.external_reconfig = True
+                log.debug("reconfig trigger file found: %s", reconfig_file)
+
+        if self.external_reconfig:
             log.debug("running in externally triggered reconfig mode")
 
         if self.gui_mode:
@@ -111,6 +119,21 @@ class InitialSetup(object):
         log.debug("initializing network logging")
         from pyanaconda.network import setup_ifcfg_log
         setup_ifcfg_log()
+
+    @property
+    def external_reconfig(self):
+        """External reconfig status.
+
+        Reports if external (eq. not triggered by kickstart) has been enabled.
+
+        :returns: True if external reconfig mode has been enabled, else False.
+        :rtype: bool
+        """
+        return self._external_reconfig
+
+    @external_reconfig.setter
+    def external_reconfig(self, value):
+        self._external_reconfig = value
 
     @property
     def gui_mode_id(self):
@@ -162,7 +185,7 @@ class InitialSetup(object):
             log.critical("Initial Setup startup failed due to invalid kickstart file")
             raise InitialSetupError
 
-        if external_reconfig:
+        if self.external_reconfig:
             # set the reconfig flag in kickstart so that
             # relevant spokes show up
             self.data.firstboot.firstboot = FIRSTBOOT_RECONFIG
@@ -211,10 +234,10 @@ class InitialSetup(object):
         log.info("executing addons")
         self.data.addons.execute(None, self.data, None, u, None)
 
-        if external_reconfig:
-            # prevent the reconfig flag from being written out,
-            # to prevent the reconfig mode from being enabled
-            # without the /etc/reconfigSys file being present
+        if self.external_reconfig:
+            # prevent the reconfig flag from being written out
+            # to kickstart if neither /etc/reconfigSys or /.unconfigured
+            # are present
             self.data.firstboot.firstboot = None
 
         # Write the kickstart data to file
@@ -223,12 +246,13 @@ class InitialSetup(object):
             f.write(str(self.data))
         log.info("finished writing the Initial Setup kickstart file")
 
-        # Remove the reconfig file, if any - otherwise the reconfig mode
-        # would start again next time the Initial Setup service is enabled
-        if external_reconfig and os.path.exists(RECONFIG_FILE):
-            log.debug("removing the reconfig file")
-            os.remove(RECONFIG_FILE)
-            log.debug("the reconfig file has been removed")
+        # Remove the reconfig files, if any - otherwise the reconfig mode
+        # would start again next time the Initial Setup service is enabled.
+        if self.external_reconfig:
+            for reconfig_file in RECONFIG_FILES:
+                if os.path.exists(reconfig_file):
+                    log.debug("removing reconfig trigger file: %s" % reconfig_file)
+                    os.remove(reconfig_file)
 
     def run(self):
         """Run Initial setup

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -140,7 +140,7 @@ class InitialSetup(object):
         """String id of the current GUI mode
 
         :returns: "gui" if gui_mode is True, "tui" otherwise
-        :rtype str:
+        :rtype: str
         """
         if self.gui_mode:
             return "gui"
@@ -204,6 +204,8 @@ class InitialSetup(object):
         # Do not execute sections that were part of the original
         # anaconda kickstart file (== have .seen flag set)
 
+        log.info("applying changes")
+
         sections = [self.data.keyboard, self.data.lang, self.data.timezone]
 
         # data.selinux
@@ -254,12 +256,15 @@ class InitialSetup(object):
                     log.debug("removing reconfig trigger file: %s" % reconfig_file)
                     os.remove(reconfig_file)
 
+        # and we are done with applying changes
+        log.info("all changes have been applied")
+
     def run(self):
         """Run Initial setup
 
         GUI will be used when the gui_mode property is True (TUI mode is the default).
 
-        :returns: True if the IS run was successfull, False if it failed
+        :returns: True if the IS run was successful, False if it failed
         :rtype: bool
         """
 
@@ -295,7 +300,7 @@ class InitialSetup(object):
             log.debug("initializing TUI")
             ui = initial_setup.tui.InitialSetupTextUserInterface(None, None, None)
 
-        # Pass the data object to user inteface
+        # Pass the data object to user interface
         log.debug("setting up the UI")
         ui.setup(self.data)
 

--- a/scripts/reconfiguration-mode-enabled
+++ b/scripts/reconfiguration-mode-enabled
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "The /.unconfigured file has been detected, enabling Initial Setup in reconfiguration mode." | systemd-cat -t initial-setup -p 6

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ data_files = [('/usr/lib/systemd/system', glob('systemd/*.service')),
               ('/usr/libexec/initial-setup/',
               ["scripts/run-initial-setup", "scripts/firstboot-windowmanager",
                "scripts/initial-setup-text", "scripts/initial-setup-graphical",
-               "scripts/graphical-service-is-deprecated", "scripts/text-service-is-deprecated"])]
+               "scripts/graphical-service-is-deprecated", "scripts/text-service-is-deprecated",
+               "reconfiguration-mode-enabled"])]
 
 # add the firstboot start script for s390 architectures
 if os.uname()[4].startswith('s390'):

--- a/systemd/initial-setup-reconfigure.service
+++ b/systemd/initial-setup-reconfigure.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Initial Setup reconfiguration mode trigger service
+After=livesys.service plymouth-quit-wait.service
+After=systemd-vconsole-setup.service
+Before=display-manager.service getty@tty1.service getty@ttyUSB0.service
+Before=serial-getty@ttyS0.service serial-getty@ttyO0.service serial-getty@ttyO2.service
+Before=serial-getty@ttyAMA0.service serial-getty@ttymxc0.service serial-getty@ttymxc3.service serial-getty@hvc0.service
+Before=initial-setup.service
+Conflicts=plymouth-quit-wait.service
+ConditionKernelCommandLine=!rd.live.image
+ConditionPathExists=/.unconfigured
+Requires=initial-setup.service
+
+[Service]
+Type=oneshot
+TimeoutSec=0
+StandardInput=tty
+StandardOutput=tty
+RemainAfterExit=yes
+ExecStart=/usr/libexec/initial-setup/reconfiguration-mode-enabled
+TimeoutSec=0
+RemainAfterExit=no
+
+[Install]
+WantedBy=graphical.target
+WantedBy=multi-user.target


### PR DESCRIPTION
The first patch adds the initial-setup-reconfiguration.service which starts initial-setup.service if /.unconfigured exists.

The IS-side machinery then runs it in the reconfig mode due to the /.unconfigured trigger file being found. It also takes care of enabling of cleaning up the trigger file once done.

The second patch is just some cleanups and logging improvements I did when working on the first patch.

BTW, for this to work the initial-setep-reconfiguration.service needs to be always enabled.That effectively means the service needs to be added to the systemd presets file to assure it is automatically enabled when the initial-setup package is installed.