### PR TITLE
Canonicalize symlinks returned by readlink

### DIFF
--- a/scripts/run-initial-setup
+++ b/scripts/run-initial-setup
@@ -11,7 +11,7 @@ GUI_INSTALLED=0
 
 # systemd targets
 GRAPHICAL_TARGET=/usr/lib/systemd/system/graphical.target
-CURRENT_DEFAULT_TARGET=$(readlink /etc/systemd/system/default.target)
+CURRENT_DEFAULT_TARGET=$(readlink -e /etc/systemd/system/default.target)
 
 WINDOWMANAGER_SCRIPT="/usr/libexec/initial-setup/firstboot-windowmanager"
 


### PR DESCRIPTION
This should make sure that the path to the current systemd default
target is resolved correctly in all relevant use cases.

Also thanks to Marek Hruscak for providing and testing this patch!

Related: rhbz#1360343