### PR TITLE
Fix 390 startup scripts

### DIFF
--- a/scripts/s390/initial-setup.csh
+++ b/scripts/s390/initial-setup.csh
@@ -1,6 +1,6 @@
 # initial-setup.csh
 
-set IS_EXEC = /lib/exec/initial-setup-text
+set IS_EXEC = /usr/libexec/initial-setup/initial-setup-text
 set IS_UNIT = initial-setup.service
 
 # the initial-setup-text.service is deprecated, use initial-setup.service instead

--- a/scripts/s390/initial-setup.csh
+++ b/scripts/s390/initial-setup.csh
@@ -11,7 +11,7 @@ set IS_UNIT_TEXT = initial-setup-text.service
 if ( ( { systemctl -q is-enabled $IS_UNIT } || { systemctl -q is-enabled $IS_UNIT_TEXT } ) && -x $IS_EXEC ) then
     # check if we're not on 3270 terminal and root
     if (( `/sbin/consoletype` == "pty" ) && ( `/usr/bin/id -u` == 0 )) then
-        $IS_EXEC
+        $IS_EXEC --no-stdout-log
         if ( $? == 0 ) then
             # everything apparently went well, disable all relevant Initial Setup units
             systemctl -q is-enabled $IS_UNIT && systemctl -q disable $IS_UNIT

--- a/scripts/s390/initial-setup.sh
+++ b/scripts/s390/initial-setup.sh
@@ -1,6 +1,6 @@
 # initial-setup.sh
 
-IS_EXEC=/lib/exec/initial-setup-text
+IS_EXEC=/usr/libexec/initial-setup/initial-setup-text
 IS_UNIT=initial-setup.service
 
 # the initial-setup-text.service is deprecated, use initial-setup.service instead

--- a/scripts/s390/initial-setup.sh
+++ b/scripts/s390/initial-setup.sh
@@ -13,7 +13,7 @@ systemctl -q is-enabled $IS_UNIT || systemctl -q is-enabled $IS_UNIT_TEXT && [ -
 if [ $IS_AVAILABLE -eq 1 ]; then
     # check if we're not on 3270 terminal and root
     if [ $(/sbin/consoletype) = "pty" ] && [ $EUID -eq 0 ]; then
-        $IS_EXEC
+        $IS_EXEC --no-stdout-log
         if [ $? == 0 ]; then
             # everything apparently went well, disable all relevant Initial Setup units
             systemctl -q is-enabled $IS_UNIT && systemctl -q disable $IS_UNIT


### PR DESCRIPTION
A couple of fixes for the Initial Setup startup scripts on the s390, needed due to recent Initial Setup changes (executable placement & logging behavior).