### PR TITLE
Fix initial-setup-reconfigure.service issues

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -73,14 +73,17 @@ make install-po-files
 %post
 %systemd_post initial-setup-text.service
 %systemd_post initial-setup.service
+%systemd_post initial-setup-reconfiguration.service
 
 %preun
 %systemd_preun initial-setup-text.service
 %systemd_preun initial-setup.service
+%systemd_preun initial-setup-reconfiguration.service
 
 %postun
 %systemd_postun initial-setup-text.service
 %systemd_postun initial-setup.service
+%systemd_postun initial-setup-reconfiguration.service
 
 %post gui
 %systemd_post initial-setup-graphical.service

--- a/scripts/reconfiguration-mode-enabled
+++ b/scripts/reconfiguration-mode-enabled
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-echo "The /.unconfigured file has been detected, enabling Initial Setup in reconfiguration mode." | systemd-cat -t initial-setup -p 6
+echo "The /.unconfigured file has been detected, starting Initial Setup in reconfiguration mode." | systemd-cat -t initial-setup -p 6
+/usr/libexec/initial-setup/run-initial-setup

--- a/systemd/initial-setup-reconfiguration.service
+++ b/systemd/initial-setup-reconfiguration.service
@@ -9,7 +9,6 @@ Before=initial-setup.service
 Conflicts=plymouth-quit-wait.service
 ConditionKernelCommandLine=!rd.live.image
 ConditionPathExists=/.unconfigured
-Requires=initial-setup.service
 
 [Service]
 Type=oneshot
@@ -17,7 +16,10 @@ TimeoutSec=0
 StandardInput=tty
 StandardOutput=tty
 RemainAfterExit=yes
+ExecStartPre=/bin/kill -55 1
+ExecStartPre=-/bin/plymouth quit
 ExecStart=/usr/libexec/initial-setup/reconfiguration-mode-enabled
+ExecStartPost=/bin/kill -54 1
 TimeoutSec=0
 RemainAfterExit=no
 


### PR DESCRIPTION
Fix some issues with the reconfig service as reported by RTT.

(A new PR as the previous one was contaminated by an unrelated commit GitHub refused to cleanup. )