### PR TITLE
Initialize SAM on startup (#1375721)

### DIFF
--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -14,6 +14,7 @@ from pykickstart.constants import FIRSTBOOT_RECONFIG
 from pyanaconda.localization import setup_locale_environment, setup_locale
 from pyanaconda.constants import FIRSTBOOT_ENVIRON
 from pyanaconda.flags import flags
+from pyanaconda import screen_access
 
 class InitialSetupError(Exception):
     pass
@@ -269,6 +270,9 @@ class InitialSetup(object):
 
         self._load_kickstart()
         self._setup_locale()
+
+        # initialize the screen access manager before launching the UI
+        screen_access.initSAM()
 
         if self.gui_mode:
             try:


### PR DESCRIPTION
Or else entering a spoke in Initial Setup
will result in a crash due to the
Screen Access Manager not being initialized.

Resolves: rhbz#1375721