### PR TITLE
Initialize SAM on startup

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 21.48.22.75
+%define anacondaver 21.48.22.102
 
 License: GPLv2+
 Group: System Environment/Base

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -25,6 +25,7 @@ from pykickstart.constants import FIRSTBOOT_RECONFIG
 from pyanaconda.localization import setup_locale_environment, setup_locale
 from pyanaconda.constants import FIRSTBOOT_ENVIRON
 from pyanaconda.flags import flags
+from pyanaconda import screen_access
 
 class InitialSetupError(Exception):
     pass
@@ -282,6 +283,9 @@ class InitialSetup(object):
 
         self._load_kickstart()
         self._setup_locale()
+
+        # initialize the screen access manager before launching the UI
+        screen_access.initSAM()
 
         if self.gui_mode:
             try:


### PR DESCRIPTION
Or else entering a spoke in Initial Setup
will result in a crash due to the
Screen Access Manager not being initialized.

Related: rhbz#1422867