### PR TITLE
Run GUI on the s390 if possible (#1378082)

### DIFF
--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -92,10 +92,10 @@ class InitialSetup(object):
         self._reboot_on_quit = False
 
         # parse any command line arguments
-        args = self._parse_arguments()
+        self.args = self._parse_arguments()
 
         # initialize logging
-        initial_setup_log.init(stdout_log=not args.no_stdout_log)
+        initial_setup_log.init(stdout_log=not self.args.no_stdout_log)
         global logging_initialized
         logging_initialized = True
 
@@ -193,6 +193,7 @@ class InitialSetup(object):
                                          description="Initial Setup can run during the first start of a newly installed"
                                          "system to configure it according to the needs of the user.")
         parser.add_argument("--no-stdout-log", action="store_true", default=False, help="don't log to stdout")
+        parser.add_argument("--show-window-header", action="store_true", default=False, help="show window header (GUI only)")
         parser.add_argument('--version', action='version', version=__version__)
 
         # parse arguments and return the result
@@ -331,6 +332,9 @@ class InitialSetup(object):
             # Initialize the UI
             log.debug("initializing GUI")
             ui = initial_setup.gui.InitialSetupGraphicalUserInterface(None, None, PostInstallClass())
+
+            # set Window header visibility based on command line options
+            ui.mainWindow.set_hide_titlebar_when_maximized(not self.args.show_window_header)
         else:
             # Import IS tui specifics
             import initial_setup.tui

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -95,7 +95,8 @@ class InitialSetup(object):
         self.args = self._parse_arguments()
 
         # initialize logging
-        initial_setup_log.init(stdout_log=not self.args.no_stdout_log)
+        initial_setup_log.init(stdout_log=not self.args.no_stdout_log,
+                               stdout_log_level=self.args.stdout_log_level)
         global logging_initialized
         logging_initialized = True
 
@@ -193,6 +194,8 @@ class InitialSetup(object):
                                          description="Initial Setup can run during the first start of a newly installed"
                                          "system to configure it according to the needs of the user.")
         parser.add_argument("--no-stdout-log", action="store_true", default=False, help="don't log to stdout")
+        parser.add_argument("--stdout-log-level", default="debug", choices=["warning", "info", "debug"],
+                            metavar="LOG_LEVEL", help='stdout log level')
         parser.add_argument("--show-window-header", action="store_true", default=False, help="show window header (GUI only)")
         parser.add_argument('--version', action='version', version=__version__)
 

--- a/initial_setup/initial_setup_log.py
+++ b/initial_setup/initial_setup_log.py
@@ -22,6 +22,11 @@
 import logging
 from logging.handlers import SysLogHandler, SYSLOG_UDP_PORT
 
+LOG_LEVEL_MAP = {"warning": logging.WARNING,
+                 "info": logging.INFO,
+                 "debug": logging.DEBUG
+                 }
+
 class InitialSetupSyslogHandler(SysLogHandler):
     """A SysLogHandler subclass that makes sure the Initial Setup
     messages are easy to identify in the syslog/Journal
@@ -41,8 +46,22 @@ class InitialSetupSyslogHandler(SysLogHandler):
         SysLogHandler.emit(self, record)
         record.msg = original_msg
 
-def init(stdout_log):
-    """Initialize the Initial Setup logging system"""
+def parse_log_level(log_level_name):
+    """Covert a string to log level constant.
+
+    We only support "warning", "info" and "critical".
+
+    :param str log_level_name: lowercase log level name
+    :returns: log level constants, logging.DEBUG if log level name is unknown
+    """
+    return LOG_LEVEL_MAP.get(log_level_name, logging.DEBUG)
+
+def init(stdout_log, stdout_log_level):
+    """Initialize the Initial Setup logging system.
+
+    :param bool stdout_log: if stdout log should be initialized
+    :param str stdout_log_level: log level name for the stdout log
+    """
     log = logging.getLogger("initial-setup")
     log.setLevel(logging.DEBUG)
     syslogHandler = InitialSetupSyslogHandler('/dev/log', SysLogHandler.LOG_LOCAL1, "initial-setup")
@@ -53,6 +72,6 @@ def init(stdout_log):
         # also log to stdout because someone is apparently running Initial Setup manually,
         # probably for debugging purposes
         stdoutHandler = logging.StreamHandler()
-        stdoutHandler.setLevel(logging.DEBUG)
+        stdoutHandler.setLevel(parse_log_level(stdout_log_level))
         stdoutHandler.setFormatter(logging.Formatter('%(levelname)s %(name)s: %(message)s'))
         log.addHandler(stdoutHandler)

--- a/scripts/run-initial-setup
+++ b/scripts/run-initial-setup
@@ -34,12 +34,25 @@ if [ $GUI_INSTALLED -eq 1 ]; then
         echo "Starting Initial Setup TUI" | systemd-cat -t initial-setup -p 6
         ${IS_TEXT} --no-stdout-log
     else
-        # don't run the GUI on text-only systems (default.target != graphical.target),
+        # Don't run the GUI on text-only systems (default.target != graphical.target),
         # users are not expecting a graphical interface do start in such case
-        # and there might not even be any displays connected
-        if [ "$CURRENT_DEFAULT_TARGET" == "$GRAPHICAL_TARGET" ]; then
+        # and there might not even be any displays connected.
+        # But do run the GUI on text-only systems that have $DISPLAY defined,
+        # as that basically indicated X-forwarding and might be used on the s390.
+        if [ "$CURRENT_DEFAULT_TARGET" == "$GRAPHICAL_TARGET" ] || [ -n "$DISPLAY" ]; then
             echo "Starting Initial Setup GUI" | systemd-cat -t initial-setup -p 6
-            ${START_GUI_COMMAND}
+            if [ -n "$DISPLAY" ]; then
+                # $DISPLAY being defined basically identifies X-forwarding. In such case
+                # we want to run Initial Setup as an application and there is no need to
+                # start our own X server and window manager.
+                # And also tell Initial Setup to show window header, so that it's
+                # window does not look out of place.
+                ${IS_GRAPHICAL} --show-window-header  --stdout-log-level=info
+            else
+                # This is not X forwarding - start X server, window manager and then
+                # graphical Initial Setup.
+                ${START_GUI_COMMAND}
+            fi
         else
             echo "Initial Setup GUI is installed, but default.target != graphical.target" | systemd-cat -t initial-setup -p 5
             echo "Starting Initial Setup TUI" | systemd-cat -t initial-setup -p 6

--- a/scripts/s390/initial-setup.csh
+++ b/scripts/s390/initial-setup.csh
@@ -1,21 +1,19 @@
 # initial-setup.csh
 
-set IS_EXEC = /usr/libexec/initial-setup/initial-setup-text
+set IS_EXEC = /usr/libexec/initial-setup/run-initial-setup
 set IS_UNIT = initial-setup.service
 
 # the initial-setup-text.service is deprecated, use initial-setup.service instead
 set IS_UNIT_TEXT = initial-setup-text.service
 
+# the initial-setup-graphical.service is deprecated, use initial-setup.service instead
+set IS_UNIT_GRAPHICAL = initial-setup-graphical.service
+
 # check if the Initial Setup unit is enabled and the executable is available
 # - either the initial-setup.service or initial-setup-text.service need to be enabled
-if ( ( { systemctl -q is-enabled $IS_UNIT } || { systemctl -q is-enabled $IS_UNIT_TEXT } ) && -x $IS_EXEC ) then
+if ( ( { systemctl -q is-enabled $IS_UNIT } || { systemctl -q is-enabled $IS_UNIT_TEXT } || { systemctl -q is-enabled $IS_UNIT_GRAPHICAL } ) && -x $IS_EXEC ) then
     # check if we're not on 3270 terminal and root
     if (( `/sbin/consoletype` == "pty" ) && ( `/usr/bin/id -u` == 0 )) then
-        $IS_EXEC --no-stdout-log
-        if ( $? == 0 ) then
-            # everything apparently went well, disable all relevant Initial Setup units
-            systemctl -q is-enabled $IS_UNIT && systemctl -q disable $IS_UNIT
-            systemctl -q is-enabled $IS_UNIT_TEXT && systemctl -q disable $IS_UNIT_TEXT
-        endif
+        $IS_EXEC
     endif
 endif

--- a/scripts/s390/initial-setup.sh
+++ b/scripts/s390/initial-setup.sh
@@ -1,23 +1,23 @@
 # initial-setup.sh
 
-IS_EXEC=/usr/libexec/initial-setup/initial-setup-text
+IS_EXEC=/usr/libexec/initial-setup/run-initial-setup
 IS_UNIT=initial-setup.service
 
 # the initial-setup-text.service is deprecated, use initial-setup.service instead
-IS_UNIT_TEXT=initial-setup.service
+IS_UNIT_TEXT=initial-setup-text.service
+# the initial-setup-graphical.service is deprecated, use initial-setup.service instead
+IS_UNIT_GRAPHICAL=initial-setup-graphical.service
 
 IS_AVAILABLE=0
 # check if the Initial Setup unit is enabled and the executable is available
-# - either the initial-setup.service or initial-setup-text.service need to be enabled
-systemctl -q is-enabled $IS_UNIT || systemctl -q is-enabled $IS_UNIT_TEXT && [ -f $IS_EXEC ] && IS_AVAILABLE=1
+# - either of the initial-setup.service, initial-setup-text.service or initial-setup graphical
+# need to be enabled
+UNIT_ENABLED=0
+systemctl -q is-enabled $IS_UNIT || systemctl -q is-enabled $IS_UNIT_TEXT || systemctl -q is-enabled $IS_UNIT_GRAPHICAL && UNIT_ENABLED=1
+[ $UNIT_ENABLED -eq 1 ] && [ -f $IS_EXEC ] && IS_AVAILABLE=1
 if [ $IS_AVAILABLE -eq 1 ]; then
     # check if we're not on 3270 terminal and root
     if [ $(/sbin/consoletype) = "pty" ] && [ $EUID -eq 0 ]; then
-        $IS_EXEC --no-stdout-log
-        if [ $? == 0 ]; then
-            # everything apparently went well, disable all relevant Initial Setup units
-            systemctl -q is-enabled $IS_UNIT && systemctl -q disable $IS_UNIT
-            systemctl -q is-enabled $IS_UNIT_TEXT && systemctl -q disable $IS_UNIT_TEXT
-        fi
+        $IS_EXEC
     fi
 fi


### PR DESCRIPTION
Run the Initial Setup GUI on the s390 if:
- the DISPLAY environmental variable is set
- either of initial-setup.service or initial-setup-graphical.service
  is enabled

This is achieved by executing the run-initial-setup script, which has
been extended to detect if $DISPLAY is set.

We can also remove the code for disabling the Initial Setup services
after successful run from the s390 startup scripts as the run-initial-setup
script already handles that.

Resolves: rhbz#1378082