### PR TITLE
Run the Initial Setup TUI on all usable consoles (#1438046)

### DIFF
--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -346,5 +346,10 @@ class InitialSetup(object):
         # apply changes
         self._apply()
 
+        # in the TUI mode shutdown the multi TTY handler
+        if not self.gui_mode:
+            # TODO: wait for this to finish or make it blockng ?
+            ui.multi_tty_handler.shutdown()
+
         # and we are done
         return True

--- a/initial_setup/common.py
+++ b/initial_setup/common.py
@@ -1,7 +1,15 @@
 """Common methods for Initial Setup"""
 
+import os
+
 from pyanaconda.ui.common import collect
 from pyanaconda.constants import FIRSTBOOT_ENVIRON
+
+# a set of excluded console names
+# - console, tty, tty0 -> these appear to be just aliases to the  default console,
+#                         leaving them in would result in duplicate input on and output from
+#                         the default console
+TUI_EXCLUDED_CONSOLES = {"console", "tty", "tty0"}
 
 def collect_spokes(mask_paths, spoke_parent_class):
     """Return a list of all spoke subclasses that should appear for a given
@@ -52,3 +60,27 @@ def collectCategoriesAndSpokes(hub_instance, spoke_parent_class):
         ret[spoke.category].append(spoke)
 
     return ret
+
+def console_filter(console_name):
+    """Filter out consoles we don't want to attempt running the TUI on.
+
+    This at the moment just means console aliases, but it's possible more
+    consoles will have to be added for other reasons in the guture.
+
+    :param str console_name: console name to check
+    :returns: if the console name is considered usable for IS TUI
+    :rtype: bool
+    """
+    return console_name not in TUI_EXCLUDED_CONSOLES
+
+def list_usable_consoles_for_tui():
+    """List suitable consoles for running the Initial Setup TUI.
+
+    We basically want to list any console a user might using,
+    as we can't really be sure which console is in use or not.
+
+    :returns: a list of console names considered usable for the IS TUI
+    :rtype: list
+    """
+    console_names = [c for c in os.listdir("/sys/class/tty/") if console_filter(c)]
+    return sorted(console_names)

--- a/initial_setup/tui/tui.py
+++ b/initial_setup/tui/tui.py
@@ -1,8 +1,14 @@
 from pyanaconda.ui.tui import TextUserInterface
+from pyanaconda import threads
 from initial_setup.product import product_title, is_final
+from initial_setup.common import list_usable_consoles_for_tui
 from .hubs import InitialSetupMainHub
 import os
+import sys
 import gettext
+import select
+import logging
+log = logging.getLogger("initial-setup")
 
 # localization
 _ = lambda x: gettext.ldgettext("initial-setup", x)
@@ -10,6 +16,118 @@ N_ = lambda x: x
 
 QUIT_MESSAGE = N_("Are you sure you want to quit the configuration process?\n"
                   "You might end up with unusable system if you do.")
+
+class MultipleTTYHandler(object):
+    """Run the Initial Setup TUI on all usable consoles.
+
+    This is done by redirecting the Initial Setup stdout to all
+    usable consoles and then redirecting any input back to
+    the Initial Setup stdin.
+    """
+
+    def __init__(self, tui_stdout_fd, tui_stdin_fd):
+        # create file objects for the TUI stdout and stdin fds
+        self._tui_stdout_fd = tui_stdout_fd
+        self._tui_stdout = os.fdopen(tui_stdout_fd, "r")
+        self._tui_stdin_fd = tui_stdin_fd
+        self._tui_stdin = os.fdopen(tui_stdin_fd, "w")
+
+        self._shutdown = False
+
+        self._console_read_fds = {}
+        self._console_write_fos = []
+        self._open_all_consoles()
+
+    def shutdown(self):
+        """Tell the multi TTY handler to shutdown."""
+        self._shutdown = True
+
+    def _open_all_consoles(self):
+        """Open all consoles suitable for running the Initial Setup TUI."""
+        console_write_fos = []
+        console_read_fds = {}
+        console_paths = (os.path.join("/dev", c) for c in list_usable_consoles_for_tui())
+        usable_console_paths = []
+        unusable_console_paths = []
+        for console_path in console_paths:
+            try:
+                write_fo = open(console_path, "w")
+                read_fo = open(console_path, "r")
+                console_write_fos.append(write_fo)
+                read_fd = read_fo.fileno()
+                # the console stdin file descriptors need to be non-blocking
+                os.set_blocking(read_fd, False)
+                console_read_fds[read_fd] = read_fo
+                # If we survived till now the console might be usable
+                # (could be read and written into).
+                usable_console_paths.append(console_path)
+            except Exception:
+                log.exception("can't open console for Initial Setup TUI: %s", console_path)
+                unusable_console_paths.append(console_path)
+
+        log.debug("The Initial Setup TUI will attempt to run on the following consoles:")
+        log.debug("\n".join(usable_console_paths))
+        log.debug("The following consoles could not be opened and will not be used:")
+        log.debug("\n".join(unusable_console_paths))
+        self._console_read_fds = console_read_fds
+        self._console_write_fos = console_write_fos
+
+    def run(self):
+        """Run IS TUI on multiple consoles."""
+        # we wait for data from the consoles
+        fds = list(self._console_read_fds.keys())
+        # as well as from the anaconda stdout
+        fds.append(self._tui_stdout_fd)
+        log.info("multi TTY handler starting")
+        while True:
+            # Watch the consoles and IS TUI stdout for data and
+            # react accordingly.
+            # The select also triggers every second (the 1.0 parameter),
+            # so that the infinite loop can be promptly interrupted once
+            # the multi TTY handler is told to shutdown.
+            rlist, _wlist, _xlist = select.select(fds, [], [], 1.0)
+            if self._shutdown:
+                log.info("multi TTY handler shutting down")
+                break
+            for fd in rlist:
+                if fd == self._tui_stdout_fd:
+                    # We need to set the TUI stdout fd to non-blocking,
+                    # as otherwise reading from it would (predictably) result in
+                    # the readline() function blocking once it runs out of data.
+                    os.set_blocking(fd, False)
+
+                    # The IS TUI wants to write something,
+                    # read all the lines.
+                    lines = self._tui_stdout.readlines()
+
+                    # After we finish reading all the data we need to set
+                    # the TUI stdout fd to blocking again.
+                    # Otherwise the fd will not be usable when we try to read from
+                    # it again for unclear reasons.
+                    os.set_blocking(fd, True)
+
+                    lines.append("\n")  # seems to get lost somewhere on the way
+
+                    # Write all the lines IS wrote to stdout to all consoles
+                    # that we consider usable for the IS TUI.
+                    for console_fo in self._console_write_fos:
+                        for one_line in lines:
+                            try:
+                                console_fo.write(one_line)
+                            except OSError:
+                                log.exception("failed to write %s to console %s", one_line, console_fo)
+                else:
+                    # Someone typed some input to a console and hit enter,
+                    # forward the input to the IS TUI stdin.
+                    fo = self._console_read_fds[fd]
+                    try:
+                        data = fo.readline()
+                    except TypeError:
+                        log.exception("input reading failed for console %s", fo)
+                        continue
+                    self._tui_stdin.write(data)
+                    self._tui_stdin.flush()
+
 
 class InitialSetupTextUserInterface(TextUserInterface):
     """This is the main text based firstboot interface. It inherits from
@@ -20,7 +138,23 @@ class InitialSetupTextUserInterface(TextUserInterface):
 
     def __init__(self, storage, payload, instclass):
         TextUserInterface.__init__(self, storage, payload, instclass,
-                                         product_title, is_final, quitMessage = QUIT_MESSAGE)
+                                   product_title, is_final, quitMessage=QUIT_MESSAGE)
+
+        # redirect stdin and stdout to custom pipes
+
+        # stdin
+        stdin_fd, tui_stdin_fd = os.pipe()
+        sys.stdin = os.fdopen(stdin_fd, "r")
+
+        # stdout
+        tui_stdout_fd, stdout_fd = os.pipe()
+        sys.stdout = os.fdopen(stdout_fd, "w")
+
+        # instantiate and start the multi TTY handler
+        self.multi_tty_handler = MultipleTTYHandler(tui_stdin_fd=tui_stdin_fd, tui_stdout_fd=tui_stdout_fd)
+        threads.threadMgr.add(
+            threads.AnacondaThread(name="such_multi_tty_thread", target=self.multi_tty_handler.run)
+        )
 
     def _list_hubs(self):
         return [InitialSetupMainHub]


### PR DESCRIPTION
This change attempts to address two issues with the Initial Setup TUI:

1) starting the TUI on a different console than the one a user
   connected to
2) starting the Initial Setup TUI on a console that is unusable.

Number 1) might generally not be a big issue on x86 PCs, where
Initial Setup is only used sporadically for simple post installation
configuration and where most users are simply using the graphical
console.

Things are much more serious for arm based single board
computers, where Initial Setup TUI more or less takes over the role of
an interactive installer, as the main installation method is image
based and the Initial Setup TUI running in reconfig mode provides
the only interactive configuration options.

Further users of arm devices make much more use of serial consoles, so
the x86 platform expectation that the user is mostly likely at the
graphical console does not hold.

Issue number 2) also has increased impact on arm devices, as arm boards
tend to have various esoteric serial consoles, some of which might not
be useable in an interactive mode. If such console is resolved as the
default one then the Initial Setup TUI might fail to open the console
and crash at startup.

The solution - run IS TUI on all useable TTYs

This should solve issue number 1) by providing access the Initial Setup
TUI regardles to what console (graphical, serial, etc.) the user is
using. It should also solve issue number 2) as consoles that can't be
opened or that fail during use are skipped.

The implementation - stdin and stdout redirection and multiplexing

The solution to issues 1) & 2) is achieved by redirecting the Initial
Setup TUI stdout and stdin to multiplexing code, which uses select() to:

- watch for any output and sends it to all useable consoles at once
- watch for input on any useable console and sends it to the
  Initial Setup stdin.

This efectively means that the Initial Setup TUI should be running on
all useable consoles and the user should be able to use any of the
consoles to interact with it.