### PR TITLE
Remove stdin & stdout definition from unit files (#1438046)

### DIFF
--- a/systemd/initial-setup-reconfiguration.service
+++ b/systemd/initial-setup-reconfiguration.service
@@ -14,8 +14,6 @@ Requires=initial-setup.service
 [Service]
 Type=oneshot
 TimeoutSec=0
-StandardInput=tty
-StandardOutput=tty
 RemainAfterExit=yes
 ExecStart=/usr/libexec/initial-setup/reconfiguration-mode-enabled
 TimeoutSec=0

--- a/systemd/initial-setup.service
+++ b/systemd/initial-setup.service
@@ -11,8 +11,6 @@ ConditionKernelCommandLine=!rd.live.image
 [Service]
 Type=oneshot
 TimeoutSec=0
-StandardInput=tty
-StandardOutput=tty
 RemainAfterExit=yes
 ExecStartPre=/bin/kill -55 1
 ExecStartPre=-/bin/plymouth quit


### PR DESCRIPTION
As initial setup now runs on all usable TTYs automatically, it no longer
needs systemd to provide it with a stdin and stdout.

This is actually a potential liability as the TTY might get resolved
to an unusable one, preventing Initial Setup from starting at all.

So remove the stdin and stdout from our service files and let the
multi-TTY handling code handle all of that.