### PR TITLE
Add support for password entry from arbitrary consoles (#1438046)

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 25.20.3
+%define anacondaver 26.21.6
 
 License: GPLv2+
 Group: System Environment/Base

--- a/initial_setup/tui/tui.py
+++ b/initial_setup/tui/tui.py
@@ -7,6 +7,9 @@ import os
 import sys
 import gettext
 import select
+import contextlib
+import termios
+import time
 import logging
 log = logging.getLogger("initial-setup")
 
@@ -34,7 +37,9 @@ class MultipleTTYHandler(object):
 
         self._shutdown = False
 
-        self._console_read_fds = {}
+        self._active_console = None
+
+        self._console_read_fos = {}
         self._console_write_fos = []
         self._open_all_consoles()
 
@@ -44,8 +49,8 @@ class MultipleTTYHandler(object):
 
     def _open_all_consoles(self):
         """Open all consoles suitable for running the Initial Setup TUI."""
-        console_write_fos = []
-        console_read_fds = {}
+        console_write_fos = {}
+        console_read_fos = {}
         console_paths = (os.path.join("/dev", c) for c in list_usable_consoles_for_tui())
         usable_console_paths = []
         unusable_console_paths = []
@@ -53,11 +58,11 @@ class MultipleTTYHandler(object):
             try:
                 write_fo = open(console_path, "w")
                 read_fo = open(console_path, "r")
-                console_write_fos.append(write_fo)
-                read_fd = read_fo.fileno()
+                fd = read_fo.fileno()
+                console_write_fos[fd] = write_fo
                 # the console stdin file descriptors need to be non-blocking
-                os.set_blocking(read_fd, False)
-                console_read_fds[read_fd] = read_fo
+                os.set_blocking(fd, False)
+                console_read_fos[fd] = read_fo
                 # If we survived till now the console might be usable
                 # (could be read and written into).
                 usable_console_paths.append(console_path)
@@ -69,13 +74,13 @@ class MultipleTTYHandler(object):
         log.debug("\n".join(usable_console_paths))
         log.debug("The following consoles could not be opened and will not be used:")
         log.debug("\n".join(unusable_console_paths))
-        self._console_read_fds = console_read_fds
+        self._console_read_fos = console_read_fos
         self._console_write_fos = console_write_fos
 
     def run(self):
         """Run IS TUI on multiple consoles."""
         # we wait for data from the consoles
-        fds = list(self._console_read_fds.keys())
+        fds = list(self._console_read_fos.keys())
         # as well as from the anaconda stdout
         fds.append(self._tui_stdout_fd)
         log.info("multi TTY handler starting")
@@ -110,7 +115,7 @@ class MultipleTTYHandler(object):
 
                     # Write all the lines IS wrote to stdout to all consoles
                     # that we consider usable for the IS TUI.
-                    for console_fo in self._console_write_fos:
+                    for console_fo in self._console_write_fos.values():
                         for one_line in lines:
                             try:
                                 console_fo.write(one_line)
@@ -119,14 +124,100 @@ class MultipleTTYHandler(object):
                 else:
                     # Someone typed some input to a console and hit enter,
                     # forward the input to the IS TUI stdin.
-                    fo = self._console_read_fds[fd]
+                    read_fo = self._console_read_fos[fd]
+                    write_fo = self._console_write_fos[fd]
+                    # as the console is getting input we consider it to be
+                    # the currently active console
+                    self._active_console = read_fo, write_fo
                     try:
-                        data = fo.readline()
+                        data = read_fo.readline()
                     except TypeError:
-                        log.exception("input reading failed for console %s", fo)
+                        log.exception("input reading failed for console %s", read_fo)
                         continue
                     self._tui_stdin.write(data)
                     self._tui_stdin.flush()
+
+    def custom_getpass(self, prompt='Password: '):
+        """Prompt for a password, with echo turned off that can run on an arbitrary console.
+
+        This implementation is based on the Python 3.6 getpass() source code, with added
+        support for running getpass() on an arbitrary console, as the original implementation
+        is hardcoded to expect input from /dev/tty, without an option to change that.
+
+        Raises:
+          EOFError: If our input tty or stdin was closed.
+
+        Always restores terminal settings before returning.
+        """
+        input_fo, output_fo = self._active_console
+        passwd = None
+        with contextlib.ExitStack() as stack:
+            input_fd = input_fo.fileno()
+            if input_fd is not None:
+                try:
+                    old = termios.tcgetattr(input_fd)     # a copy to save
+                    new = old[:]
+                    new[3] &= ~termios.ECHO  # 3 == 'lflags'
+                    tcsetattr_flags = termios.TCSAFLUSH
+                    if hasattr(termios, 'TCSASOFT'):
+                        tcsetattr_flags |= termios.TCSASOFT
+                    try:
+                        termios.tcsetattr(input_fd, tcsetattr_flags, new)
+                        passwd = self._raw_input(prompt, output_fo, input_fo=input_fo)
+                    finally:
+                        termios.tcsetattr(input_fd, tcsetattr_flags, old)
+                        output_fo.flush()  # Python issue7208
+                except termios.error:
+                    if passwd is not None:
+                        # _raw_input succeeded.  The final tcsetattr failed.  Reraise
+                        # instead of leaving the terminal in an unknown state.
+                        raise
+                    # We can't control the tty or stdin.  Give up and use normal IO.
+                    # _fallback_getpass() raises an appropriate warning.
+                    if output_fo is not input_fo:
+                        # clean up unused file objects before blocking
+                        stack.close()
+                    passwd = self._fallback_getpass(prompt, output_fo, input_fo)
+
+            output_fo.write('\n')
+            return passwd
+
+    def _fallback_getpass(self, prompt='Password: ', output_fo=None, input_fo=None):
+        log.warning("Can not control echo on the terminal: %s", input_fo)
+        if not output_fo:
+            output_fo = sys.stderr
+        print("Warning: Password input may be echoed.", file=output_fo)
+        return self._raw_input(prompt, output_fo, input_fo)
+
+
+    def _raw_input(self, prompt="", output_fo=None, input_fo=None):
+        # This doesn't save the string in the GNU readline history.
+
+        # The input fd has to be set as non-blocking for the general multi-tty machinery
+        # to work, but for password input to work correctly it needs to be set as blocking
+        # when user input is expected.
+        # We also have to switch it back to non-blocking once user input is received.
+        os.set_blocking(input_fo.fileno(), True)
+        prompt = str(prompt)
+        if prompt:
+            try:
+                output_fo.write(prompt)
+            except UnicodeEncodeError:
+                # Use replace error handler to get as much as possible printed.
+                prompt = prompt.encode(output_fo.encoding, 'replace')
+                prompt = prompt.decode(output_fo.encoding)
+                output_fo.write(prompt)
+            output_fo.flush()
+        # NOTE: The Python C API calls flockfile() (and unlock) during readline.
+        line = input_fo.readline()
+        if not line:
+            raise EOFError
+        if line[-1] == '\n':
+            line = line[:-1]
+        # We got input from the user, switch the input fd back to non-blocking
+        # so that the multi-tty machinery works correctly.
+        os.set_blocking(input_fo.fileno(), False)
+        return line
 
 
 class InitialSetupTextUserInterface(TextUserInterface):
@@ -152,9 +243,17 @@ class InitialSetupTextUserInterface(TextUserInterface):
 
         # instantiate and start the multi TTY handler
         self.multi_tty_handler = MultipleTTYHandler(tui_stdin_fd=tui_stdin_fd, tui_stdout_fd=tui_stdout_fd)
+        # start the multi-tty handler
         threads.threadMgr.add(
             threads.AnacondaThread(name="such_multi_tty_thread", target=self.multi_tty_handler.run)
         )
+
+    def setup(self, data):
+        TextUserInterface.setup(self, data)
+        # Make sure custom getpass() from multi-tty handler is used instead of regular getpass.
+        # This needs to be done as the default getpass() implementation cant work with arbitrary
+        # consoles and always defaults to /dev/tty for input.
+        self.simpleline_app.simpleline_getpass = self.multi_tty_handler.custom_getpass
 
     def _list_hubs(self):
         return [InitialSetupMainHub]


### PR DESCRIPTION
The getpass() function provided by the getpass module from the Python
standard library is used by the Anaconda/Initial Setup TUI for password
input. The getpass() function does this:

- provides a password prompt (eq. "Password:" or something similar)
- hides user input when user is typing the password

Unfortunately the default getpass() is hardcoded to expect user input
from /dev/tty, so it does not work with the recently added Initial Setup
multi-tty support.

To fix this a custom getpass() implementation (based on the default one)
has been added, which supports asking the user for password on an
arbitrary console. On the Anaconda side support has been added for using
custom getpass() implementation.

Like this users should be able to safely input passwords on any console
where the Initial Setup TUI can run.

Also bump the Anaconda version as we now need the Anaconda side
support for using a custom getpass() function.