### PR TITLE
Use getty-pre.target to prevent getty from running (#1488535)

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -31,6 +31,7 @@ BuildRequires: python-di
 
 Requires: python
 Requires: anaconda-tui >= %{anacondaver}
+Requires: systemd >= 219-44
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd

--- a/systemd/initial-setup-graphical.service
+++ b/systemd/initial-setup-graphical.service
@@ -2,9 +2,11 @@
 Description=Initial Setup configuration program graphical interface
 After=livesys.service plymouth-quit-wait.service
 After=systemd-vconsole-setup.service
-Before=display-manager.service getty@tty1.service getty@ttyUSB0.service
-Before=serial-getty@ttyS0.service serial-getty@ttyO0.service serial-getty@ttyO2.service
-Before=serial-getty@ttyAMA0.service serial-getty@ttymxc0.service serial-getty@ttymxc3.service serial-getty@hvc0.service
+# getty-pre.target is a pasive target, we need to request it before we can use it
+Wants=getty-pre.target
+# prevent getty from running on any consoles before we are done
+Before=getty-pre.target
+Before=display-manager.service
 Before=initial-setup.service
 Conflicts=plymouth-quit-wait.service
 ConditionKernelCommandLine=!rd.live.image

--- a/systemd/initial-setup-reconfiguration.service
+++ b/systemd/initial-setup-reconfiguration.service
@@ -2,9 +2,11 @@
 Description=Initial Setup reconfiguration mode trigger service
 After=livesys.service plymouth-quit-wait.service
 After=systemd-vconsole-setup.service
-Before=display-manager.service getty@tty1.service getty@ttyUSB0.service
-Before=serial-getty@ttyS0.service serial-getty@ttyO0.service serial-getty@ttyO2.service
-Before=serial-getty@ttyAMA0.service serial-getty@ttymxc0.service serial-getty@ttymxc3.service serial-getty@hvc0.service
+# getty-pre.target is a pasive target, we need to request it before we can use it
+Wants=getty-pre.target
+# prevent getty from running on any consoles before we are done
+Before=getty-pre.target
+Before=display-manager.service
 Before=initial-setup.service
 Conflicts=plymouth-quit-wait.service
 ConditionKernelCommandLine=!rd.live.image

--- a/systemd/initial-setup-text.service
+++ b/systemd/initial-setup-text.service
@@ -2,9 +2,11 @@
 Description=Initial Setup configuration program text interface
 After=livesys.service plymouth-quit-wait.service
 After=systemd-vconsole-setup.service
-Before=display-manager.service getty@tty1.service getty@ttyUSB0.service
-Before=serial-getty@ttyS0.service serial-getty@ttyO0.service serial-getty@ttyO2.service
-Before=serial-getty@ttyAMA0.service serial-getty@ttymxc0.service serial-getty@ttymxc3.service serial-getty@hvc0.service
+# getty-pre.target is a pasive target, we need to request it before we can use it
+Wants=getty-pre.target
+# prevent getty from running on any consoles before we are done
+Before=getty-pre.target
+Before=display-manager.service
 Before=initial-setup.service
 Conflicts=plymouth-quit-wait.service
 ConditionKernelCommandLine=!rd.live.image

--- a/systemd/initial-setup.service
+++ b/systemd/initial-setup.service
@@ -3,9 +3,11 @@ Description=Initial Setup configuration program
 After=livesys.service plymouth-quit-wait.service
 After=systemd-vconsole-setup.service
 After=initial-setup-graphical.service initial-setup-text.service
-Before=display-manager.service getty@tty1.service getty@ttyUSB0.service
-Before=serial-getty@ttyS0.service serial-getty@ttyO0.service serial-getty@ttyO2.service
-Before=serial-getty@ttyAMA0.service serial-getty@ttymxc0.service serial-getty@ttymxc3.service serial-getty@hvc0.service
+# getty-pre.target is a pasive target, we need to request it before we can use it
+Wants=getty-pre.target
+# prevent getty from running on any consoles before we are done
+Before=getty-pre.target
+Before=display-manager.service
 Conflicts=plymouth-quit-wait.service
 ConditionKernelCommandLine=!rd.live.image
 


### PR DESCRIPTION
Use the getty-pre.target to prevent getty from running on
any console before Initial Setup finishes running.

We need to prevent getty from running otherwise it would
interfere with displaying the TUI in text mode and we also
don't want to enable user login before Initial Setup is done,
as final system configuration an user account creation might
take place.

Using the getty-pre.target should be much more robust than the
previous solution that required listing all possible consoles by name.

Resolves: rhbz#1488535