### PR TITLE
Automated release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ local: po-pull
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 
 rpmlog:
-	@git log --pretty="format:- %s (%ae)" $(TAG).. |sed -e 's/@.*)/)/'
+	@git log --no-merges --pretty="format:- %s (%ae)" $(TAG).. |sed -e 's/@.*)/)/'
 	@echo
 
 po-files:

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,11 @@ tag:
 	git tag -a -m "Tag as $(TAG)" -f $(TAG)
 	@echo "Tagged as $(TAG)"
 
-release: tag archive
+release:
+	$(MAKE) bumpver
+	$(MAKE) commit
+	$(MAKE) tag
+	$(MAKE) archive
 
 archive: po-pull
 	@rm -f ChangeLog
@@ -104,5 +108,9 @@ bumpver: potfile
 	sed -i "s/Version: $(VERSION)/Version: $$NEWVERSION/" initial-setup.spec ; \
 	sed -i "s/version = \"$(VERSION)\"/version = \"$$NEWVERSION\"/" setup.py ; \
 	sed -i "s/__version__ = \"$(VERSION)\"/__version__ = \"$$NEWVERSION\"/" initial_setup/__init__.py ; \
+
+commit:
+	git add initial-setup.spec initial_setup/__init__.py po/initial-setup.pot setup.py ; \
+	git commit -m "New version $(VERSION)" ; \
 
 .PHONY: clean install tag archive local


### PR DESCRIPTION
Add the moment one needs to call the "bumpver" target,
then manually create the release commit and then
call the "release" target, which tags the commit and
creates the tarball. This is pretty repetitive and
should be automated.

So add a new target called "commit" which creates a proper
release commit and make sure the release target
call the "bumpver" & "commit" targets before tagging and
creating the tarball.

This should turn a nominal Initial Setup release to typing:

make release

And everything will be done automatically in this order:
- bumpver
- release commit
- release tag
- tarball creation

Also remove merge commits from the changelog in spec file.