### PR TITLE
Run Boss during the Initial Setup run

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -146,6 +146,7 @@ fi
 %{_libexecdir}/%{name}/initial-setup-text
 %{_libexecdir}/%{name}/reconfiguration-mode-enabled
 %{_unitdir}/initial-setup.service
+%{_unitdir}/initial-setup-boss.service
 %{_unitdir}/initial-setup-reconfiguration.service
 
 %ifarch s390 s390x

--- a/systemd/initial-setup-boss.service
+++ b/systemd/initial-setup-boss.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Start Initial Setup Boss
+Before=initial-setup.service
+
+[Service]
+Type=dbus
+BusName=org.fedoraproject.Anaconda.Boss
+ExecStart=/usr/bin/python3 -m pyanaconda.modules.boss

--- a/systemd/initial-setup.service
+++ b/systemd/initial-setup.service
@@ -2,6 +2,8 @@
 Description=Initial Setup configuration program
 After=livesys.service plymouth-quit-wait.service
 After=systemd-vconsole-setup.service
+Requires=initial-setup-boss.service
+After=initial-setup-boss.service
 # getty-pre.target is a pasive target, we need to request it before we can use it
 Wants=getty-pre.target
 # prevent getty from running on any consoles before we are done


### PR DESCRIPTION
Boss, the centerpiece of modular DBUS using Anaconda needs to be running
not only during an Anaconda installation run, but in Initial Setup as
well.

So add Boss DBUS service file and make sure the serviuce runs during
Initial Setup startup.