### PR TITLE
Make sure correct return code is emitted by the startup script

### DIFF
--- a/scripts/run-initial-setup
+++ b/scripts/run-initial-setup
@@ -72,6 +72,8 @@ if [ $? -eq 0 ]; then
     systemctl -q is-enabled $IS_UNIT && systemctl disable $IS_UNIT
     systemctl -q is-enabled $IS_UNIT_TEXT && systemctl disable $IS_UNIT_TEXT
     systemctl -q is-enabled $IS_UNIT_GRAPHICAL 2>/dev/null && systemctl disable $IS_UNIT_GRAPHICAL
+    exit 0
 else
     echo "Initial Setup failed, keeping enabled" | systemd-cat -t initial-setup -p 3
+    exit 1
 fi


### PR DESCRIPTION
We need to explicitly call exit at the end of the startup script or
else the exit code of the last run command will propagate as the script
exit code, even if the Initial Setup run was successful.

The last run command for a successful Initial Setup run is:

"systemctl -q is-enabled $IS_UNIT_GRAPHICAL 2>/dev/null && systemctl disable $IS_UNIT_GRAPHICAL"

It can easily happen that "systemctl is-enabled" will return a non-zero
return code if the given unit is not enabled.

This is especially problematic as systemd will mark the unit as failed
if it's startup script returns a non-zero return code. This has a
significant potential to confuse users and cause false positives
(everything is actually fine as IS finished running successfully
and correctly disabled it's units from running again).

Related: rhbz#1524785