### PR TITLE
Return correct code at startup script success/failure

### DIFF
--- a/scripts/run-initial-setup
+++ b/scripts/run-initial-setup
@@ -35,6 +35,8 @@ if [ $? -eq 0 ]; then
     echo "Initial Setup finished successfully, disabling" | systemd-cat -t initial-setup -p 6
     systemctl -q is-enabled $IS_UNIT && systemctl disable $IS_UNIT
     echo "Initial Setup has been disabled" | systemd-cat -t initial-setup -p 6
+    exit 0
 else
     echo "Initial Setup failed, keeping enabled" | systemd-cat -t initial-setup -p 3
+    exit 1
 fi


### PR DESCRIPTION
Explicitly run "exit 0" at success and "exit 1" at failure of an
Initial Setup run. Otherwise successfully runs might be reported by
systemd (which reads the return code of the startup script) as failed
and failed runs as successful (as the last command is just echo
outputting the error message).