### PR TITLE
Adjust to Hub behavior change

### DIFF
--- a/initial_setup/gui/hubs/initial_setup_hub.py
+++ b/initial_setup/gui/hubs/initial_setup_hub.py
@@ -13,6 +13,12 @@ class InitialSetupMainHub(Hub):
     translationDomain = "initial-setup"
     helpFile = "InitialSetupHub.xml"
 
+    # Should we automatically go to next hub if processing is done and there are no
+    # spokes on the hub ? The correct value for Initial Setup is True, due to the
+    # long standing Initial Setup policy of continuing with system startup if there
+    # are no spokes to be shown.
+    continue_if_empty = True
+
     def __init__(self, *args):
         Hub.__init__(self, *args)
 


### PR DESCRIPTION
The continue_if_empty property has been added to graphical Hubs
to handle the case where the hub is empty during the Workstation
Live installation. While it makes sense for Anaconda to *not* autoquit
if the last hub is empty, it has always been the standard behavior
in Initial Setup. So override the default value for the Initial Setup GUI hub.