### PR TITLE
Adapt to a new Simpleline input handling

### DIFF
--- a/initial_setup/tui/tui.py
+++ b/initial_setup/tui/tui.py
@@ -256,9 +256,8 @@ class InitialSetupTextUserInterface(TextUserInterface):
         # Make sure custom getpass() from multi-tty handler is used instead of regular getpass.
         # This needs to be done as the default getpass() implementation cant work with arbitrary
         # consoles and always defaults to /dev/tty for input.
-        screen_scheduler = App.get_scheduler()
-        io_manager = screen_scheduler.io_manager
-        io_manager.set_pass_func(self.multi_tty_handler.custom_getpass)
+        configuration = App.get_configuration()
+        configuration.password_function = self.multi_tty_handler.custom_getpass
 
     def _list_hubs(self):
         return [InitialSetupMainHub]


### PR DESCRIPTION
Simpleline doesn't have default password function setter anymore. This should be done in the UIScreen from now on.

It's hard for me to test initial-setup so please test it before merge @M4rtinK . Thanks.

This requires https://github.com/rhinstaller/anaconda/pull/1418 PR before merge.