### PR TITLE
Use the Anaconda default for DBUS module timeout

### DIFF
--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -344,7 +344,7 @@ class InitialSetup(object):
         atexit.register(self.cleanup_dbus_session)
 
         # Make sure that all DBus modules are ready.
-        if not startup_utils.wait_for_modules(timeout=30):
+        if not startup_utils.wait_for_modules():
             log.error("Anaconda DBus modules failed to start on time.")
             return True
 


### PR DESCRIPTION
There is currently no good reason to set a different
timeout value from what Anaconda uses.