### PR TITLE
Add support for showing an EULA spoke

### DIFF
--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -10,6 +10,7 @@ import traceback
 import atexit
 from pyanaconda.users import Users
 from initial_setup.post_installclass import PostInstallClass
+from initial_setup.product import eula_available
 from initial_setup import initial_setup_log
 from pyanaconda.core import util
 from pyanaconda.localization import setup_locale_environment, setup_locale
@@ -91,6 +92,8 @@ class InitialSetup(object):
         self.gui_mode = gui_mode
         # kickstart data
         self.data = None
+        # reboot on quit flag
+        self._reboot_on_quit = False
 
         # parse any command line arguments
         args = self._parse_arguments()
@@ -190,6 +193,11 @@ class InitialSetup(object):
             return "gui"
         else:
             return "tui"
+
+    @property
+    def reboot_on_quit(self):
+        # should the machine be rebooted once Initial Setup quits
+        return self._reboot_on_quit
 
     def _parse_arguments(self):
         """Parse command line arguments"""
@@ -390,6 +398,11 @@ class InitialSetup(object):
         # Start the application
         log.info("starting the UI")
         ret = ui.run()
+
+        # we need to reboot the machine if there is an EULA, that was not agreed
+        if eula_available() and  not self.data.eula.agreed:
+            log.warning("EULA has not been agreed - the system will be rebooted.")
+            self._reboot_on_quit = True
 
         # TUI returns False if the app was ended prematurely
         # all other cases return True or None

--- a/initial_setup/common.py
+++ b/initial_setup/common.py
@@ -4,6 +4,8 @@ import os
 
 from pyanaconda.ui.common import collect
 from pyanaconda.core.constants import FIRSTBOOT_ENVIRON
+from pyanaconda.core.i18n import N_
+from pyanaconda.ui.categories import SpokeCategory
 
 # a set of excluded console names
 # - console, tty, tty0 -> these appear to be just aliases to the  default console,
@@ -125,3 +127,9 @@ def os_bug_report_url(filename='/etc/os-release'):
     """
     osrel = parse_os_release_file(filename)
     return osrel.get('BUG_REPORT_URL')
+
+class LicensingCategory(SpokeCategory):
+    displayOnHubGUI = "ProgressHub"
+    displayOnHubTUI = "SummaryHub"
+    sortOrder = 100
+    title = N_("LICENSING")

--- a/initial_setup/gui/gui.py
+++ b/initial_setup/gui/gui.py
@@ -1,5 +1,5 @@
 from pyanaconda.ui.gui import QuitDialog, GraphicalUserInterface
-from initial_setup.product import product_title, is_final
+from initial_setup.product import product_title, is_final, eula_available
 from .hubs import InitialSetupMainHub
 import os
 from gi.repository import Gdk
@@ -9,9 +9,17 @@ import gettext
 _ = lambda x: gettext.ldgettext("initial-setup", x)
 N_ = lambda x: x
 
+def get_quit_message():
+    if eula_available():
+        return N_("Are you sure you want to quit the configuration process?\n"
+                  "You might end up with an unusable system if you do. Unless the "
+                  "License agreement is accepted, the system will be rebooted.")
+    else:
+        return N_("Are you sure you want to quit the configuration process?\n"
+                  "You might end up with unusable system if you do.")
+
 class InitialSetupQuitDialog(QuitDialog):
-    MESSAGE = N_("Are you sure you want to quit the configuration process?\n"
-                 "You might end up with unusable system if you do.")
+    MESSAGE = get_quit_message()
 
 class InitialSetupGraphicalUserInterface(GraphicalUserInterface):
     """This is the main Gtk based firstboot interface. It inherits from

--- a/initial_setup/gui/spokes/eula.glade
+++ b/initial_setup/gui/spokes/eula.glade
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <!-- interface-requires gtk+ 3.6 -->
+  <!-- interface-requires AnacondaWidgets 1.0 -->
+  <object class="GtkTextBuffer" id="eulaBuffer">
+    <property name="text">The license will go here</property>
+  </object>
+  <object class="AnacondaSpokeWindow" id="eulaWindow">
+    <property name="can_focus">False</property>
+    <property name="hexpand">True</property>
+    <property name="vexpand">True</property>
+    <property name="window_name" translatable="yes">LICENSE INFORMATION</property>
+    <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
+    <child internal-child="main_box">
+      <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child internal-child="nav_box">
+          <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
+            <property name="can_focus">False</property>
+            <child internal-child="nav_area">
+              <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">
+                <property name="can_focus">False</property>
+                <property name="margin_left">6</property>
+                <property name="margin_right">6</property>
+                <property name="margin_top">6</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child internal-child="alignment">
+          <object class="GtkAlignment" id="AnacondaSpokeWindow-alignment1">
+            <property name="can_focus">False</property>
+            <property name="xscale">0.80000001192092896</property>
+            <property name="yscale">0.80000001192092896</property>
+            <child internal-child="action_area">
+              <object class="GtkBox" id="mainBox">
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel" id="licenseAgreementLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin_top">24</property>
+                    <property name="margin_bottom">6</property>
+                    <property name="label" translatable="yes">License Agreement:</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="eulaBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="eulaScrolledWindow">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="shadow_type">in</property>
+                        <child>
+                          <object class="GtkTextView" id="eulaView">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="margin_bottom">18</property>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="vscroll_policy">natural</property>
+                            <property name="pixels_above_lines">12</property>
+                            <property name="editable">False</property>
+                            <property name="wrap_mode">word</property>
+                            <property name="left_margin">12</property>
+                            <property name="right_margin">12</property>
+                            <property name="cursor_visible">False</property>
+                            <property name="buffer">eulaBuffer</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="agreeCheckButton">
+                        <property name="label" translatable="yes">I _accept the license agreement.</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="xalign">0</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_check_button_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/initial_setup/gui/spokes/eula.py
+++ b/initial_setup/gui/spokes/eula.py
@@ -1,0 +1,114 @@
+"""EULA spoke for the Initial Setup"""
+
+import gettext
+import logging
+
+from pyanaconda.ui.common import FirstbootOnlySpokeMixIn
+from pyanaconda.ui.gui.spokes import NormalSpoke
+from pykickstart.constants import FIRSTBOOT_RECONFIG
+
+from initial_setup.product import eula_available, get_license_file_name
+from initial_setup.common import LicensingCategory
+
+log = logging.getLogger("initial-setup")
+
+_ = lambda x: gettext.ldgettext("initial-setup", x)
+N_ = lambda x: x
+
+__all__ = ["EULASpoke"]
+
+class EULASpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
+    """The EULA spoke"""
+
+    builderObjects = ["eulaBuffer", "eulaWindow"]
+    mainWidgetName = "eulaWindow"
+    uiFile = "eula.glade"
+    # The EULA spoke is self-explanatory, so just redirect its
+    # help button to the Initial Setup Hub help file,
+    # which covers the overall theory of Initial Setup
+    # usage.
+    helpFile = "InitialSetupHub.xml"
+
+    icon = "application-certificate-symbolic"
+    title = N_("_LICENSE INFORMATION")
+    category = LicensingCategory
+    translationDomain = "initial-setup"
+
+    def initialize(self):
+        log.debug("initializing the EULA spoke")
+        NormalSpoke.initialize(self)
+
+        self._have_eula = True
+        self._eula_buffer = self.builder.get_object("eulaBuffer")
+        self._agree_check_button = self.builder.get_object("agreeCheckButton")
+        self._agree_label = self._agree_check_button.get_child()
+        self._agree_text = self._agree_label.get_text()
+
+        log.debug("looking for the license file")
+        license_file = get_license_file_name()
+        if not license_file:
+            log.error("no license found")
+            self._have_eula = False
+            self._eula_buffer.set_text(_("No license found. Please report this "
+                                         "at http://bugzilla.redhat.com"))
+            return
+
+        self._eula_buffer.set_text("")
+        itr = self._eula_buffer.get_iter_at_offset(0)
+        log.debug("opening the license file")
+        with open(license_file, "r") as fobj:
+            # insert the first line without prefixing with space
+            try:
+                first_line = next(fobj)
+            except StopIteration:
+                # nothing in the file
+                return
+            self._eula_buffer.insert(itr, first_line.strip())
+
+            # EULA file is preformatted for the console, we want to let Gtk
+            # format it (blank lines should be preserved)
+            for line in fobj:
+                stripped_line = line.strip()
+                if stripped_line:
+                    self._eula_buffer.insert(itr, " " + stripped_line)
+                else:
+                    self._eula_buffer.insert(itr, "\n\n")
+
+    def refresh(self):
+        self._agree_check_button.set_sensitive(self._have_eula)
+        self._agree_check_button.set_active(self.data.eula.agreed)
+
+    def apply(self):
+        self.data.eula.agreed = self._agree_check_button.get_active()
+
+    @property
+    def completed(self):
+        return not self._have_eula or self.data.eula.agreed
+
+    @property
+    def status(self):
+        if not self._have_eula:
+            return _("No license found")
+
+        return _("License accepted") if self.data.eula.agreed else _("License not accepted")
+
+    @classmethod
+    def should_run(cls, environment, data):
+        # the EULA spoke should only run if both are true:
+        # - we are running in Initial Setup
+        # - an EULA is available
+        if eula_available() and FirstbootOnlySpokeMixIn.should_run():
+            # don't run if we are in reconfig mode and the EULA has already been accepted
+            if data and data.firstboot.firstboot == FIRSTBOOT_RECONFIG and data.eula.agreed:
+                log.debug("not running license spoke: reconfig mode & license already accepted")
+                return False
+            return True
+        return False
+
+    def on_check_button_toggled(self, checkbutton, *args):
+        if self._agree_check_button.get_active():
+            log.debug("license is now accepted")
+            self._agree_label.set_markup("<b>%s</b>" % self._agree_text)
+        else:
+            log.debug("license no longer accepted")
+            self._agree_label.set_markup(self._agree_text)

--- a/initial_setup/product.py
+++ b/initial_setup/product.py
@@ -1,7 +1,13 @@
 """Module providing information about the installed product."""
 import logging
 
+from pyanaconda.localization import find_best_locale_match
+from pyanaconda.core.constants import DEFAULT_LANG
+import os
+import glob
+
 RELEASE_STRING_FILE = "/etc/os-release"
+LICENSE_FILE_GLOB = "/usr/share/redhat-release*/EULA*"
 
 log = logging.getLogger("initial-setup")
 
@@ -37,3 +43,48 @@ def is_final():
 
     # doesn't really matter for the Initial Setup
     return True
+
+def get_license_file_name():
+    """Get filename of the license file best matching current localization settings.
+
+    :return: filename of the license file or None if no license file found
+    :rtype: str or None
+    """
+
+    all_eulas = glob.glob(LICENSE_FILE_GLOB)
+    non_localized_eulas = []
+    langs = set()
+    for eula in all_eulas:
+        if "EULA_" in eula:
+            # license file for a specific locale
+            lang = eula.rsplit("EULA_", 1)[1]
+            if lang:
+                langs.add(lang)
+        else:
+            non_localized_eulas.append(eula)
+
+    best_lang = find_best_locale_match(os.environ["LANG"], langs)
+    if not best_lang:
+        # nothing found for the current language, try the default one
+        best_lang = find_best_locale_match(DEFAULT_LANG, langs)
+
+    if not best_lang:
+        # nothing found even for the default language, use non-localized or None
+        if non_localized_eulas:
+            best_eula = non_localized_eulas[0]
+        else:
+            return None
+    else:
+        # use first of the best-matching EULA files (there should be only one)
+        best_eula = glob.glob(LICENSE_FILE_GLOB + ("_%s" % best_lang))[0]
+
+    return best_eula
+
+def eula_available():
+    """ Report if it looks like there is an EULA available on the system.
+
+    :return: True if an EULA seems to be available, False otherwise
+    :rtype: bool
+    """
+    return bool(get_license_file_name())
+

--- a/initial_setup/tui/spokes/eula.py
+++ b/initial_setup/tui/spokes/eula.py
@@ -1,0 +1,128 @@
+"""EULA TUI spoke for the Initial Setup"""
+
+import gettext
+import codecs
+import logging
+
+from pyanaconda.ui.tui.spokes import NormalTUISpoke
+from simpleline.render.widgets import TextWidget, CheckboxWidget, SeparatorWidget
+from simpleline.render.containers import ListRowContainer
+from simpleline.render.screen import UIScreen, InputState
+from simpleline.render.screen_handler import ScreenHandler
+from pyanaconda.ui.common import FirstbootOnlySpokeMixIn
+from initial_setup.product import get_license_file_name, eula_available
+from initial_setup.common import LicensingCategory
+from pykickstart.constants import FIRSTBOOT_RECONFIG
+
+log = logging.getLogger("initial-setup")
+
+_ = lambda x: gettext.ldgettext("initial-setup", x)
+N_ = lambda x: x
+
+__all__ = ["EULASpoke"]
+
+
+class EULASpoke(FirstbootOnlySpokeMixIn, NormalTUISpoke):
+    """The EULA spoke providing ways to read the license and agree/disagree with it."""
+
+    category = LicensingCategory
+
+    def __init__(self, *args, **kwargs):
+        NormalTUISpoke.__init__(self, *args, **kwargs)
+        self.title = _("License information")
+        self._container = None
+
+    def initialize(self):
+        NormalTUISpoke.initialize(self)
+
+    def refresh(self, args=None):
+        NormalTUISpoke.refresh(self, args)
+
+        self._container = ListRowContainer(1)
+
+        log.debug("license found")
+        # make the options aligned to the same column (the checkbox has the
+        # '[ ]' prepended)
+        self._container.add(TextWidget("%s\n" % _("Read the License Agreement")),
+                            self._show_license_screen_callback)
+
+        self._container.add(CheckboxWidget(title=_("I accept the license agreement."),
+                                           completed=self.data.eula.agreed),
+                            self._license_accepted_callback)
+        self.window.add_with_separator(self._container)
+
+    @property
+    def completed(self):
+        # Either there is no EULA available, or user agrees/disagrees with it.
+        return self.data.eula.agreed
+
+    @property
+    def mandatory(self):
+        # This spoke is always mandatory.
+        return True
+
+    @property
+    def status(self):
+        return _("License accepted") if self.data.eula.agreed else _("License not accepted")
+
+    @classmethod
+    def should_run(cls, environment, data):
+        # the EULA spoke should only run in Initial Setup
+        if eula_available() and FirstbootOnlySpokeMixIn.should_run():
+            # don't run if we are in reconfig mode and the EULA has already been accepted
+            if data and data.firstboot.firstboot == FIRSTBOOT_RECONFIG and data.eula.agreed:
+                log.debug("not running license spoke: reconfig mode & license already accepted")
+                return False
+            return True
+        return False
+
+    def apply(self):
+        # nothing needed here, the agreed field is changed in the input method
+        pass
+
+    def input(self, args, key):
+        if not self._container.process_user_input(key):
+            return key
+
+        return InputState.PROCESSED
+
+    @staticmethod
+    def _show_license_screen_callback(data):
+        # show license
+        log.debug("showing the license")
+        eula_screen = LicenseScreen()
+        ScreenHandler.push_screen(eula_screen)
+
+    def _license_accepted_callback(self, data):
+        # toggle EULA agreed checkbox by changing ksdata
+        log.debug("license accepted state changed to: %s", self.data.eula.agreed)
+        self.data.eula.agreed = not self.data.eula.agreed
+        self.redraw()
+
+
+class LicenseScreen(UIScreen):
+    """Screen showing the License without any input from user requested."""
+
+    def __init__(self, screen_height=25):
+        super().__init__(screen_height=screen_height)
+
+        self._license_file = get_license_file_name()
+
+    def refresh(self, args=None):
+        super().refresh(args)
+
+        # read the license file and make it one long string so that it can be
+        # processed by the TextWidget to fit in the screen in a best possible
+        # way
+        log.debug("reading the license file")
+        buf = u""
+        with codecs.open(self._license_file, "r", "utf-8", "ignore") as fobj:
+            for line in fobj:
+                buf += line
+
+        self.window.add_with_separator(TextWidget(buf))
+
+    def prompt(self, args=None):
+        # we don't want to prompt user, just close the screen
+        self.close()
+        return None

--- a/initial_setup/tui/tui.py
+++ b/initial_setup/tui/tui.py
@@ -1,7 +1,7 @@
 from pyanaconda.ui.tui import TextUserInterface
 from pyanaconda import threading
 
-from initial_setup.product import product_title, is_final
+from initial_setup.product import product_title, is_final, eula_available
 from initial_setup.common import list_usable_consoles_for_tui
 from .hubs import InitialSetupMainHub
 
@@ -20,8 +20,16 @@ log = logging.getLogger("initial-setup")
 _ = lambda x: gettext.ldgettext("initial-setup", x)
 N_ = lambda x: x
 
-QUIT_MESSAGE = N_("Are you sure you want to quit the configuration process?\n"
+def get_quit_message():
+    if eula_available():
+        return N_("Are you sure you want to quit the configuration process?\n"
+                  "You might end up with an unusable system if you do. Unless the "
+                  "License agreement is accepted, the system will be rebooted.")
+    else:
+        return N_("Are you sure you want to quit the configuration process?\n"
                   "You might end up with unusable system if you do.")
+
+QUIT_MESSAGE = get_quit_message()
 
 class MultipleTTYHandler(object):
     """Run the Initial Setup TUI on all usable consoles.

--- a/scripts/initial-setup-graphical
+++ b/scripts/initial-setup-graphical
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+import os
+
 from initial_setup import InitialSetup, InitialSetupError
 
 is_instance = InitialSetup(gui_mode=True)
@@ -9,6 +11,11 @@ try:
 except InitialSetupError:
     # Initial Setup with graphical interface apparently failed
     exit(1)
+
+# check if we should reboot the machine instead of continuing to
+# the login screen
+if is_instance.reboot_on_quit:
+    os.system("reboot")
 
 # Initial Setup with graphical interface completed successfully
 exit(0)

--- a/scripts/initial-setup-text
+++ b/scripts/initial-setup-text
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+import os
+
 from initial_setup import InitialSetup, InitialSetupError
 
 is_instance = InitialSetup(gui_mode=False)
@@ -9,6 +11,11 @@ try:
 except InitialSetupError:
     # Initial Setup using with text interface apparently failed
     exit(1)
+
+# check if we should reboot the machine instead of continuing to
+# the login screen
+if is_instance.reboot_on_quit:
+    os.system("reboot")
 
 # Initial Setup using with text interface completed successfully
 exit(0)


### PR DESCRIPTION
There are cases when it might be useful to show some sort of a license
or other text users should see before they start using the computer.

So add a new spoke that only shows up if such license text file is present.
Also if the file exists make sure users have to agree with it before
they can continue.

If no license text file is present the EULA spoke will not be shown
and Initial Setup will behave in a normal way.