### PR TITLE
Use the configuration file in DBus modules

### DIFF
--- a/data/10-initial-setup.conf
+++ b/data/10-initial-setup.conf
@@ -1,0 +1,13 @@
+# Initial Setup configuration file
+# Here are changes in the Anaconda configuration that are specific for the Initial Setup
+
+
+[Anaconda]
+# List of enabled kickstart modules.
+kickstart_modules =
+     org.fedoraproject.Anaconda.Modules.Timezone
+     org.fedoraproject.Anaconda.Modules.Network
+     org.fedoraproject.Anaconda.Modules.Localization
+     org.fedoraproject.Anaconda.Modules.Security
+     org.fedoraproject.Anaconda.Modules.Users
+     org.fedoraproject.Anaconda.Modules.Services

--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 29.13
+%define anacondaver 30.9
 
 License: GPLv2+
 Group: System Environment/Base
@@ -149,6 +149,7 @@ fi
 %{_libexecdir}/%{name}/reconfiguration-mode-enabled
 %{_unitdir}/initial-setup.service
 %{_unitdir}/initial-setup-reconfiguration.service
+%{_sysconfdir}/anaconda/conf.d/10-initial-setup.conf
 
 %ifarch s390 s390x
 %{_sysconfdir}/profile.d/initial-setup.sh

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ def read(fname):
 
 
 data_files = [('/usr/lib/systemd/system', glob('systemd/*.service')),
+              ('/etc/anaconda/conf.d', glob('data/*.conf')),
               ('/usr/libexec/initial-setup/',
               ["scripts/run-initial-setup", "scripts/firstboot-windowmanager",
                "scripts/initial-setup-text", "scripts/initial-setup-graphical",


### PR DESCRIPTION
Use the configuration file to specify the required kickstart modules
and use the Anaconda DBus launcher to start and stop them.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/1663