### PR TITLE
Specify the type of the installation system (#1685992)

### DIFF
--- a/data/10-initial-setup.conf
+++ b/data/10-initial-setup.conf
@@ -13,6 +13,12 @@ kickstart_modules =
      org.fedoraproject.Anaconda.Modules.Services
 
 
+[Installation System]
+# Type of the installation system.
+# FIXME: This is a temporary solution.
+type = BOOTED_OS
+
+
 [User Interface]
 # Default help pages for TUI, GUI and Live OS.
 default_help_pages =

--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 30.15
+%define anacondaver 30.25.3-4
 
 License: GPLv2+
 Group: System Environment/Base


### PR DESCRIPTION
Specify the type of the installation system in the Anaconda
configuration file.

Resolves: rhbz#1685992
**Depends on:** https://github.com/rhinstaller/anaconda/pull/1880