### PR TITLE
Adjust to changes in the Users DBus module

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 30.25.3-4
+%define anacondaver 31.12-1
 
 License: GPLv2+
 BuildRequires: gettext


### PR DESCRIPTION
The user group, user and root password configuration code
has been moved to DBus Tasks, so we need to run those in
Initial Setup instead of the old kickstart command overrides.

Also we no longer can access the parsed kickstart commands directly
to inspect the seen property as the Anaconda side command handlers have
been dropped. So check if user groups/users/root password appear to
be configured at Initial Setup startup and use this information
when deciding to run the given configuration task.