### PR TITLE
Read configuration files from /etc/initial-setup/conf.d (#1713506)

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -149,7 +149,9 @@ fi
 %{_libexecdir}/%{name}/reconfiguration-mode-enabled
 %{_unitdir}/initial-setup.service
 %{_unitdir}/initial-setup-reconfiguration.service
-%{_sysconfdir}/anaconda/conf.d/10-initial-setup.conf
+%dir %{_sysconfdir}/%{name}
+%dir %{_sysconfdir}/%{name}/conf.d
+%config %{_sysconfdir}/%{name}/conf.d/*
 
 %ifarch s390 s390x
 %{_sysconfdir}/profile.d/initial-setup.sh

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -143,7 +143,7 @@ class InitialSetup(object):
         # Too bad anaconda does not have modularized logging
         log.debug("initializing the Anaconda log")
         from pyanaconda import anaconda_logging
-        anaconda_logging.init()
+        anaconda_logging.init(write_to_journal=True)
 
         # create class for launching our dbus session
         self._dbus_launcher = AnacondaDBusLauncher()

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -98,6 +98,10 @@ class InitialSetup(object):
             log.critical("Initial Setup needs to be run as root")
             raise InitialSetupError
 
+        # load configuration files
+        from pyanaconda.core.configuration.anaconda import conf
+        conf.set_from_files(["/etc/initial-setup/conf.d/"])
+
         if self.gui_mode:
             log.debug("running in GUI mode")
         else:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def read(fname):
 
 
 data_files = [('/usr/lib/systemd/system', glob('systemd/*.service')),
-              ('/etc/anaconda/conf.d', glob('data/*.conf')),
+              ('/etc/initial-setup/conf.d', glob('data/*.conf')),
               ('/usr/libexec/initial-setup/',
               ["scripts/run-initial-setup", "scripts/firstboot-windowmanager",
                "scripts/initial-setup-text", "scripts/initial-setup-graphical",


### PR DESCRIPTION
Don't read configuration files for anaconda. Use a special directory
for the initial-setup at /etc/initial-setup/conf.d. Then anaconda can
coexist with the initial setup on the same system without influencing
each other.

Resolves: rhbz#1713506
**Depends on:** https://github.com/rhinstaller/anaconda/pull/1989