### PR TITLE
Set physical and system roots in the configuration file

### DIFF
--- a/data/10-initial-setup.conf
+++ b/data/10-initial-setup.conf
@@ -19,6 +19,14 @@ kickstart_modules =
 type = BOOTED_OS
 
 
+[Installation Target]
+# A path to the physical root of the target.
+physical_root = /
+
+# A path to the system root of the target.
+system_root = /
+
+
 [User Interface]
 # Default help pages for TUI, GUI and Live OS.
 default_help_pages =

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -41,9 +41,6 @@ SUPPORTED_KICKSTART_COMMANDS = ["user",
 # set the environment so that spokes can behave accordingly
 flags.environs = [FIRSTBOOT_ENVIRON]
 
-# set root to "/", we are now in the installed system
-util.setSysroot("/")
-
 signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 # setup logging


### PR DESCRIPTION
Paths to the physical and system roots of the target can be set in
the configuration file. The path is always /, so it is not necessary
to set up the system root.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/1996