### PR TITLE
Correct the name for libreport Python3 require

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -33,7 +33,7 @@ Requires: systemd >= 235
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
-Requires: libreport-python3
+Requires: python3-libreport
 Requires: util-linux
 Conflicts: firstboot < 19.2
 


### PR DESCRIPTION
The name of the package changed after [1].

We kept a provide for libreport-python3 but it will be removed with new release of libreport.

[1] https://fedoraproject.org/wiki/FinalizingFedoraSwitchtoPython3#Packages_with_Python_modules

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>