### PR TITLE
Fix EULA spoke header background

### DIFF
--- a/initial_setup/gui/spokes/eula.glade
+++ b/initial_setup/gui/spokes/eula.glade
@@ -18,7 +18,6 @@
         <property name="spacing">6</property>
         <child internal-child="nav_box">
           <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
-            <property name="app_paintable">True</property>
             <property name="can_focus">False</property>
             <child internal-child="nav_area">
               <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">


### PR DESCRIPTION
Drop the app_paintable option preventing the EULA spoke
header from having the correct background color.

Resolves: rhbz#1488705