### PR TITLE
Fix typo in reconfig mode detection (#1752554)

### DIFF
--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -267,7 +267,7 @@ class InitialSetup(object):
         log.info("applying changes")
 
         services_proxy = SERVICES.get_proxy()
-        reconfig_mode = services_proxy.SetSetupOnBoot == SETUP_ON_BOOT_RECONFIG
+        reconfig_mode = services_proxy.SetupOnBoot == SETUP_ON_BOOT_RECONFIG
 
         sections = [self.data.keyboard, self.data.lang, self.data.timezone]
 


### PR DESCRIPTION
Fix typo in reconfig mode detection - we need to compare a constant
against the SetupOnBoot property, not the SetSetupOnBoot method. :P

Resolves: rhbz#1752554