### PR TITLE
Bump Anaconda version due to networking changes

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 31.12-1
+%define anacondaver 32.10-1
 
 License: GPLv2+
 BuildRequires: gettext


### PR DESCRIPTION
In 297c7705cb6c3574995b5620cf53bb934d3705fc we have adjusted
Initial Setup for some Anaconda API changes, but without bumping
the required Anaconda version accordingly, so do that now.

Related: rhbz#1757960