### PR TITLE
Run the installation tasks of the Timezone module

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 32.10-1
+%define anacondaver 32.13-1
 
 License: GPLv2+
 BuildRequires: gettext

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -270,16 +270,13 @@ class InitialSetup(object):
         services_proxy = SERVICES.get_proxy()
         reconfig_mode = services_proxy.SetupOnBoot == SETUP_ON_BOOT_RECONFIG
 
-        sections = [self.data.keyboard, self.data.timezone]
+        sections = [self.data.keyboard]
 
         # data.selinux
         # data.firewall
 
         localization_proxy = LOCALIZATION.get_proxy()
         self.data.keyboard.seen = localization_proxy.KeyboardKickstarted
-
-        timezone_proxy = TIMEZONE.get_proxy()
-        self.data.timezone.seen = timezone_proxy.Kickstarted
 
         log.info("executing kickstart")
         for section in sections:
@@ -289,6 +286,12 @@ class InitialSetup(object):
                 continue
             log.debug("executing %s", section_msg)
             section.execute()
+
+        # Configure the timezone.
+        timezone_proxy = TIMEZONE.get_proxy()
+        for task_path in timezone_proxy.InstallWithTasks():
+            task_proxy = TIMEZONE.get_proxy(task_path)
+            sync_run_task(task_proxy)
 
         # Configure the localization.
         for task_path in localization_proxy.InstallWithTasks():


### PR DESCRIPTION
Don't use the `execute` method of the kickstart command `timezone`,
because this method was replaced with DBus tasks.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/2177