### PR TITLE
Fix import of the DBus launcher

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 32.13-1
+%define anacondaver 32.15-1
 
 License: GPLv2+
 BuildRequires: gettext

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -14,7 +14,7 @@ from pyanaconda.localization import setup_locale_environment, setup_locale
 from pyanaconda.core.constants import FIRSTBOOT_ENVIRON, SETUP_ON_BOOT_RECONFIG, \
     SETUP_ON_BOOT_DEFAULT
 from pyanaconda.flags import flags
-from pyanaconda.dbus.launcher import AnacondaDBusLauncher
+from pyanaconda.core.startup.dbus_launcher import AnacondaDBusLauncher
 from pyanaconda.modules.common.task import sync_run_task
 from pyanaconda.modules.common.constants.services import BOSS, LOCALIZATION, TIMEZONE, USERS, \
     SERVICES, NETWORK


### PR DESCRIPTION
The DBus launcher was moved to `pyanaconda.core.startup.dbus_launcher` during
the removal of the DBus support from Anaconda.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/2205