### PR TITLE
Remove outdated dependency on python3-libreport

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -33,7 +33,6 @@ Requires: systemd >= 235
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
-Requires: python3-libreport
 Requires: util-linux
 Conflicts: firstboot < 19.2
 


### PR DESCRIPTION
The libreport library is not used directly in this project. It is brought in indirectly via meh, where it is correctly declared.