### PR TITLE
Use macro for Python 3 requirement in spec file

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -26,7 +26,7 @@ BuildRequires: glade-devel
 BuildRequires: anaconda >= %{anacondaver}
 BuildRequires: intltool
 
-Requires: python3
+Requires: %{__python3}
 Requires: anaconda-tui >= %{anacondaver}
 Requires: python3-simpleline >= 1.4
 Requires: systemd >= 235


### PR DESCRIPTION
Use the %{__python3 macro for the Python 3 Requires:
in the spec file. This is compatible with Fedora,
RHEL and CentOS, reducing unnecessary spec file
differences.