### PR TITLE
Do not build Initial Setup on i686

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -48,6 +48,11 @@ Requires: xorg-x11-xinit
 Requires: xorg-x11-server-Xorg
 Requires: %{name} = %{version}-%{release}
 
+# native i686 installations are not supported on RHEL8 and Initial Setup
+# is not a i686 compatibility library, so building it for i686 does not
+# make sense
+ExcludeArch: i686
+
 %description gui
 The initial-setup-gui package contains a graphical user interface for the
 initial-setup utility.


### PR DESCRIPTION
As native i686 installations are not supported on RHEL8
and Initial Setup is not a i686 compatibility library, it makes
no sense to build it for the i686 architecture.

This also fixes an issue with Anaconda depending on kexec-tools,
which has dropped i686 build.This prevents Initial Setup from being
built due to transitive dependency on i686 kexec-tools package that
no longer exists.

Related: rhbz#1696277