### PR TITLE
Disable multi TTY handler when running in SSH session

### DIFF
--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -81,10 +81,10 @@ class InitialSetup(object):
         self._reboot_on_quit = False
 
         # parse any command line arguments
-        args = self._parse_arguments()
+        self._args = self._parse_arguments()
 
         # initialize logging
-        initial_setup_log.init(stdout_log=not args.no_stdout_log)
+        initial_setup_log.init(stdout_log=not self._args.no_stdout_log)
         global logging_initialized
         logging_initialized = True
 
@@ -189,6 +189,8 @@ class InitialSetup(object):
                                          description="Initial Setup is can run during the first start of a newly installed"
                                          "system to configure it according to the needs of the user.")
         parser.add_argument("--no-stdout-log", action="store_true", default=False, help="don't log to stdout")
+        parser.add_argument("--no-multi-tty", action="store_true", default=False,
+                            help="Don't run on multiple consoles.")
         parser.add_argument('--version', action='version', version=__version__)
 
         # parse arguments and return the result
@@ -409,7 +411,7 @@ class InitialSetup(object):
 
             # Initialize the UI
             log.debug("initializing TUI")
-            ui = initial_setup.tui.InitialSetupTextUserInterface()
+            ui = initial_setup.tui.InitialSetupTextUserInterface(self._args)
 
         # Pass the data object to user interface
         log.debug("setting up the UI")
@@ -433,8 +435,8 @@ class InitialSetup(object):
         # apply changes
         self._apply()
 
-        # in the TUI mode shutdown the multi TTY handler
-        if not self.gui_mode:
+        # in the TUI mode shutdown the multi TTY handler (if any)
+        if not self.gui_mode and ui.multi_tty_handler:
             # TODO: wait for this to finish or make it blockng ?
             ui.multi_tty_handler.shutdown()
 

--- a/scripts/s390/initial-setup.csh
+++ b/scripts/s390/initial-setup.csh
@@ -7,6 +7,6 @@ set IS_UNIT = initial-setup.service
 if ( { systemctl -q is-enabled $IS_UNIT } && -x $IS_EXEC ) then
     # check if we're not on 3270 terminal and root
     if (( `/sbin/consoletype` == "pty" ) && ( `/usr/bin/id -u` == 0 )) then
-        $IS_EXEC --no-stdout-log && systemctl -q is-enabled $IS_UNIT && systemctl -q disable $IS_UNIT
+        $IS_EXEC --no-stdout-log --no-multi-tty && systemctl -q is-enabled $IS_UNIT && systemctl -q disable $IS_UNIT && systemctl -q stop $IS_UNIT
     endif
 endif

--- a/scripts/s390/initial-setup.sh
+++ b/scripts/s390/initial-setup.sh
@@ -9,6 +9,6 @@ systemctl -q is-enabled $IS_UNIT && [ -f $IS_EXEC ] && IS_AVAILABLE=1
 if [ $IS_AVAILABLE -eq 1 ]; then
     # check if we're not on 3270 terminal and root
     if [ $(/sbin/consoletype) = "pty" ] && [ $EUID -eq 0 ]; then
-        $IS_EXEC --no-stdout-log && systemctl -q is-enabled $IS_UNIT && systemctl -q disable $IS_UNIT
+        $IS_EXEC --no-stdout-log --no-multi-tty && systemctl -q is-enabled $IS_UNIT && systemctl -q disable $IS_UNIT && systemctl -q stop $IS_UNIT
     fi
 fi


### PR DESCRIPTION
On the s390 Initial Setup is started upon SSH login by
a profile script.

The multi TTY handler is not really intended to handle this
usecase, so disable it when starting Initial Setup in the
SSH session. This is achieved via the new --no-multi-tty
command line option, which disables multi TTY handler
when passed to Initial Setup at startup.

Also make sure to not only disable the Initial Setup service
but also to stop it upon successful completion of Initial Setup
via SSH. Otherwise the "regular" Initial Setup might still
be running and blocking login on graphical and serial consoles.

Resolves: rhbz#1676439