### PR TITLE
Add PEP8 Speaks configuration

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,7 @@
+# Repository configuration for pep8speaks GitHup App
+
+scanner:
+    linter: pycodestyle
+
+pycodestyle:  # Same as scanner.linter value. Other option is flake8
+    max-line-length: 99  # Default is 79 in PEP 8


### PR DESCRIPTION
Otherwise PEP8 Speaks will enforce the built in limit of 79
characters per line.

The configuration file is currently the same as used by Anaconda.