### PR TITLE
Fix translations for EULA spoke related strings

### DIFF
--- a/initial_setup/common.py
+++ b/initial_setup/common.py
@@ -4,7 +4,7 @@ import os
 
 from pyanaconda.ui.common import collect
 from pyanaconda.core.constants import FIRSTBOOT_ENVIRON
-from pyanaconda.core.i18n import N_
+from initial_setup.i18n import N_, _
 from pyanaconda.ui.categories import SpokeCategory
 
 from initial_setup.product import eula_available
@@ -148,4 +148,4 @@ class LicensingCategory(SpokeCategory):
     displayOnHubGUI = "ProgressHub"
     displayOnHubTUI = "SummaryHub"
     sortOrder = 100
-    title = N_("LICENSING")
+    title = _("LICENSING")

--- a/initial_setup/gui/spokes/eula.py
+++ b/initial_setup/gui/spokes/eula.py
@@ -32,6 +32,11 @@ class EULASpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
     category = LicensingCategory
     translationDomain = "initial-setup"
 
+    def __init__(self, *args, **kwargs):
+        NormalSpoke.__init__(self, *args, **kwargs)
+        # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1673071
+        self.title = _(self.title)
+
     def initialize(self):
         log.debug("initializing the EULA spoke")
         NormalSpoke.initialize(self)


### PR DESCRIPTION
There were two strings that were not translated due to
wrong translation context - the Licensing category name
and the EULA spoke status message. In both cases the strings
were just marked for translation with N_() only to be translated
with _() from Anaconda with the "anaconda" context instead of
the correct context of "initial-setup" or translated with _()
imported from Anaconda.

For the category name, just switch to Initial Setup localization module
and translate the category name directly.

For the EULA spoke title, use workaround similar to one used
by the OSCAP addon - see bug 1673071 for more details.

Resolves: rhbz#1814952