### PR TITLE
Adapt to category title translation fix in Anaconda

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 32.15-1
+%define anacondaver 34.9-1
 
 License: GPLv2+
 BuildRequires: gettext

--- a/initial_setup/common.py
+++ b/initial_setup/common.py
@@ -4,7 +4,7 @@ import os
 
 from pyanaconda.ui.common import collect
 from pyanaconda.core.constants import FIRSTBOOT_ENVIRON
-from pyanaconda.core.i18n import N_
+from initial_setup.i18n import _, N_
 from pyanaconda.ui.categories import SpokeCategory
 
 from initial_setup.product import eula_available
@@ -145,7 +145,11 @@ def get_quit_message():
                   "You might end up with unusable system if you do.")
 
 class LicensingCategory(SpokeCategory):
-    displayOnHubGUI = "ProgressHub"
-    displayOnHubTUI = "SummaryHub"
-    sortOrder = 100
-    title = N_("LICENSING")
+
+    @staticmethod
+    def get_title():
+        return _("LICENSING")
+
+    @staticmethod
+    def get_sort_order():
+        return 100


### PR DESCRIPTION
To fix a long standing problem with localization of spoke category
titles due to translation context missmatch Anaconda moved the category
title from class attribute to a static method. The static method is
evaluated at runtime so should always have the correct translation
context and up to date locale.