### PR TITLE
Adjust to logging command changes in Anaconda (#1891621)

### DIFF
--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -34,7 +34,6 @@ SUPPORTED_KICKSTART_COMMANDS = ["user",
                                 "lang",
                                 "rootpw",
                                 "timezone",
-                                "logging",
                                 "selinux",
                                 "firewall"]
 


### PR DESCRIPTION
The logic for the logging command changeed in Anaconda and we need to
adjust accordingly. As we don't really need to handle the logging
command, we can do this by just dropping it from the list.

Resolves: rhbz#1891621