### PR TITLE
Migrate COPR builds from Jenkins to Packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -18,3 +18,14 @@ jobs:
     metadata:
       targets:
         - fedora-eln
+
+  - job: copr_build
+    trigger: commit
+    metadata:
+      targets:
+        - fedora-rawhide
+        - fedora-eln
+      branch: master
+      owner: "@rhinstaller"
+      project: Anaconda
+      preserve_project: True


### PR DESCRIPTION
With this configuration all merged commits will be automatically build to our COPR repository.

My [TEST](https://github.com/jkonecny12/initial-setup/commit/4406251545ec87fb02384d8044704df832e439cc)