### PR TITLE
Load the product configuration files

### DIFF
--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -9,7 +9,7 @@ import argparse
 import traceback
 import atexit
 
-from initial_setup.product import eula_available
+from initial_setup.product import eula_available, get_product_name
 from initial_setup import initial_setup_log
 
 from pyanaconda.core.dbus import DBus
@@ -103,7 +103,13 @@ class InitialSetup(object):
             raise InitialSetupError
 
         # load configuration files
+        from pyanaconda.core.configuration.base import ConfigurationError
         from pyanaconda.core.configuration.anaconda import conf
+        try:
+            conf.set_from_product(get_product_name())
+        except ConfigurationError as e:
+            log.warning(str(e))
+
         conf.set_from_files(["/etc/initial-setup/conf.d/"])
 
         if self.gui_mode:

--- a/initial_setup/gui/gui.py
+++ b/initial_setup/gui/gui.py
@@ -1,5 +1,5 @@
 from pyanaconda.ui.gui import QuitDialog, GraphicalUserInterface
-from initial_setup.product import product_title, is_final
+from initial_setup.product import get_product_title, is_final
 from initial_setup.common import get_quit_message
 from .hubs import InitialSetupMainHub
 import os
@@ -17,7 +17,7 @@ class InitialSetupGraphicalUserInterface(GraphicalUserInterface):
     screenshots_directory = "/tmp/initial-setup-screenshots"
 
     def __init__(self):
-        GraphicalUserInterface.__init__(self, None, None, product_title, is_final,
+        GraphicalUserInterface.__init__(self, None, None, get_product_title, is_final(),
                                         quitDialog=InitialSetupQuitDialog)
         self.mainWindow.set_title("")
 

--- a/initial_setup/gui/hubs/initial_setup_hub.py
+++ b/initial_setup/gui/hubs/initial_setup_hub.py
@@ -30,5 +30,5 @@ class InitialSetupMainHub(Hub):
 
         # override spokes' distribution strings set by the pyanaconda module
         for spoke in self._spokes.values():
-            spoke.window.set_property("distribution",
-                                      product.product_title().upper())
+            title = product.get_product_title().upper()
+            spoke.window.set_property("distribution", title)

--- a/initial_setup/product.py
+++ b/initial_setup/product.py
@@ -1,48 +1,33 @@
 """Module providing information about the installed product."""
 import logging
 
-from pyanaconda.localization import find_best_locale_match
-from pyanaconda.core.constants import DEFAULT_LANG
-import os
-import glob
-
-RELEASE_STRING_FILE = "/etc/os-release"
-LICENSE_FILE_GLOB = "/usr/share/redhat-release*/EULA*"
+from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.util import get_os_release_value
 
 log = logging.getLogger("initial-setup")
 
 
-def product_title():
+def get_product_name():
+    """Get a product name
+
+    :return: a product name
     """
-    Get product title.
+    return get_os_release_value("NAME") or ""
 
-    :return: product title
-    :rtype: str
 
+def get_product_title():
+    """Get product title.
+
+    :return: a product title
     """
-
-    try:
-        with open(RELEASE_STRING_FILE, "r") as fobj:
-            for line in fobj:
-                (key, _eq, value) = line.strip().partition("=")
-                if not key or not _eq or not value:
-                    continue
-                if key == "PRETTY_NAME":
-                    return value.strip('"')
-    except IOError:
-        log.exception("failed to check the release string file")
-
-    return ""
+    return get_os_release_value("PRETTY_NAME") or ""
 
 
 def is_final():
-    """
-    Whether it is a final release of the product or not.
+    """Whether it is a final release of the product or not.
 
     :rtype: bool
-
     """
-
     # doesn't really matter for the Initial Setup
     return True
 
@@ -53,39 +38,11 @@ def get_license_file_name():
     :return: filename of the license file or None if no license file found
     :rtype: str or None
     """
-
-    all_eulas = glob.glob(LICENSE_FILE_GLOB)
-    non_localized_eulas = []
-    langs = set()
-    for eula in all_eulas:
-        if "EULA_" in eula:
-            # license file for a specific locale
-            lang = eula.rsplit("EULA_", 1)[1]
-            if lang:
-                langs.add(lang)
-        else:
-            non_localized_eulas.append(eula)
-
-    best_lang = find_best_locale_match(os.environ["LANG"], langs)
-    if not best_lang:
-        # nothing found for the current language, try the default one
-        best_lang = find_best_locale_match(DEFAULT_LANG, langs)
-
-    if not best_lang:
-        # nothing found even for the default language, use non-localized or None
-        if non_localized_eulas:
-            best_eula = non_localized_eulas[0]
-        else:
-            return None
-    else:
-        # use first of the best-matching EULA files (there should be only one)
-        best_eula = glob.glob(LICENSE_FILE_GLOB + ("_%s" % best_lang))[0]
-
-    return best_eula
+    return conf.license.eula or None
 
 
 def eula_available():
-    """ Report if it looks like there is an EULA available on the system.
+    """Report if it looks like there is an EULA available on the system.
 
     :return: True if an EULA seems to be available, False otherwise
     :rtype: bool

--- a/initial_setup/tui/hubs/initial_setup_hub.py
+++ b/initial_setup/tui/hubs/initial_setup_hub.py
@@ -10,7 +10,7 @@ __all__ = ["InitialSetupMainHub"]
 class InitialSetupMainHub(TUIHub):
     categories = ["user", "localization"]
 
-    prod_title = product.product_title()
+    prod_title = product.get_product_title()
     if prod_title:
         title = N_("Initial setup of %(product)s") % {"product": prod_title}
     else:

--- a/initial_setup/tui/tui.py
+++ b/initial_setup/tui/tui.py
@@ -1,7 +1,7 @@
 from pyanaconda.ui.tui import TextUserInterface
 from pyanaconda import threading
 
-from initial_setup.product import product_title, is_final
+from initial_setup.product import get_product_title, is_final
 from initial_setup.common import list_usable_consoles_for_tui, get_quit_message
 from .hubs import InitialSetupMainHub
 
@@ -253,7 +253,7 @@ class InitialSetupTextUserInterface(TextUserInterface):
     ENVIRONMENT = "firstboot"
 
     def __init__(self):
-        TextUserInterface.__init__(self, None, None, product_title, is_final,
+        TextUserInterface.__init__(self, None, None, get_product_title, is_final(),
                                    quitMessage=QUIT_MESSAGE)
 
         # redirect stdin and stdout to custom pipes


### PR DESCRIPTION
Load the product configuration files to have the right defaults. Use
the product name from the os-release files of the system environment.
Simplify the product-related code.