### PR TITLE
Drop python-nose from the dependencies (#1916799)

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -19,7 +19,6 @@ License: GPLv2+
 BuildRequires: gettext
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
-BuildRequires: python3-nose
 BuildRequires: systemd-units
 BuildRequires: gtk3-devel
 BuildRequires: glade-devel

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(name="initial-setup",
           "": ["*.glade"]
       },
       data_files=data_files,
-      setup_requires=['nose>=1.0'],
       test_suite="initial_setup",
       classifiers=[
           "Development Status :: 3 - Alpha",


### PR DESCRIPTION
The initial setup doesn't use it.

Resolves: rhbz#1916799