### PR TITLE
Add support for using Mutter as window manager

### DIFF
--- a/scripts/firstboot-windowmanager
+++ b/scripts/firstboot-windowmanager
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # This is the list of supported window manager binaries
-WMS=("metacity" "kwin_x11" "kwin" "xfwm4" "openbox" "marco")
+WMS=("mutter" "metacity" "kwin_x11" "kwin" "xfwm4" "openbox" "marco")
 
 run_metacity()
 {
@@ -12,6 +12,17 @@ run_metacity()
         new_data_dirs="/usr/share/anaconda/window-manager:${XDG_DATA_DIRS}"
     fi
     XDG_DATA_DIRS="$new_data_dirs" $1 &
+}
+
+run_mutter()
+{
+    if [ -z "$XDG_DATA_DIRS" ] ; then
+        new_data_dirs="/usr/share/anaconda/window-manager:/usr/share"
+    else
+        new_data_dirs="/usr/share/anaconda/window-manager:${XDG_DATA_DIRS}"
+    fi
+    # tell Mutter we want a X11 session, or else it will get confused
+    XDG_SESSION_TYPE="x11" XDG_DATA_DIRS="$new_data_dirs" $1 &
 }
 
 # Get the application binary to start and remove it from
@@ -25,7 +36,11 @@ for WM in ${WMS[@]}; do
 
     if [ $FOUND -eq 0 -a -x "$FILE" ]; then
         # start window manager
-        if [ "$WM" == "metacity" ]; then
+        if [ "$WM" == "mutter" ]; then
+            # if running Mutter apply the Anaconda/Initial Setup custom overrides
+            echo "Running Mutter with custom overrides" | systemd-cat -t initial-setup -p 6
+            run_mutter "$FILE"
+        elif [ "$WM" == "metacity" ]; then
             # if running Metacity apply the Anaconda/Initial Setup custom overrides
             echo "Running Metacity with custom overrides" | systemd-cat -t initial-setup -p 6
             run_metacity "$FILE"


### PR DESCRIPTION
Make it possible to run Initial Setup also with Mutter as the WM.

To avoid Mutter getting confused we need to tell it what session to use
(at the moment an X11 session as Initial Setup GUI still runs as root)
or else Initial Setup would not run full screen & there would be no
window decorations for application windows IS launches (yelp, connection
editor).

Thanks a lot to Jonas Adahl for the suggestion to set XDG_SESSION_TYPE,
which fixed all the issues! :)