### PR TITLE
Drop build time dependency on the anaconda package

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -22,7 +22,6 @@ BuildRequires: python3-setuptools
 BuildRequires: systemd-units
 BuildRequires: gtk3-devel
 BuildRequires: glade-devel
-BuildRequires: anaconda >= %{anacondaver}
 BuildRequires: intltool
 BuildRequires: make
 


### PR DESCRIPTION
It's not clear why Initial Setup had a build time dependency on
the anaconda package, but it was probably something related to how
translations and translation contexts used to be handled.

With the category translation fix introduced a couple months ago
this should be no longer relevant and also preliminary scratch builds
don't indicate any issues if the "BuildRequires: anaconda" line is
dropped, so we should be safe to drop the build time dependency on the
anaconda package.