### PR TITLE
Use profiles instead of product configuration files

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 34.9-1
+%define anacondaver 35.19-1
 
 License: GPLv2+
 BuildRequires: gettext

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -9,10 +9,11 @@ import argparse
 import traceback
 import atexit
 
-from initial_setup.product import eula_available, get_product_name
+from initial_setup.product import eula_available
 from initial_setup import initial_setup_log
 
 from pyanaconda.core.dbus import DBus
+from pyanaconda.core.util import get_os_release_value
 from pyanaconda.localization import setup_locale_environment, setup_locale
 from pyanaconda.core.constants import FIRSTBOOT_ENVIRON, SETUP_ON_BOOT_RECONFIG, \
     SETUP_ON_BOOT_DEFAULT
@@ -106,7 +107,9 @@ class InitialSetup(object):
         from pyanaconda.core.configuration.base import ConfigurationError
         from pyanaconda.core.configuration.anaconda import conf
         try:
-            conf.set_from_product(get_product_name())
+            conf.set_from_detected_profile(
+                get_os_release_value("ID")
+            )
         except ConfigurationError as e:
             log.warning(str(e))
 

--- a/initial_setup/product.py
+++ b/initial_setup/product.py
@@ -7,14 +7,6 @@ from pyanaconda.core.util import get_os_release_value
 log = logging.getLogger("initial-setup")
 
 
-def get_product_name():
-    """Get a product name
-
-    :return: a product name
-    """
-    return get_os_release_value("NAME") or ""
-
-
 def get_product_title():
     """Get product title.
 


### PR DESCRIPTION
The support for product configuration files was removed and replaced with profiles.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/3388
Related: rhbz#1974819