### PR TITLE
Fix ownership of the gui folder (#1812463)

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -101,7 +101,7 @@ rm -rf %{buildroot}
 
 %files gui
 %{_libexecdir}/%{name}/initial-setup-graphical
-%{python3_sitelib}/initial_setup/gui
+%{python3_sitelib}/initial_setup/gui/
 
 %changelog
 * Mon Jul 12 2021 Martin Kolman <mkolman@redhat.com> - 0.3.93-1

--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -101,7 +101,7 @@ rm -rf %{buildroot}
 
 %files gui
 %{_libexecdir}/%{name}/initial-setup-graphical
-%{python3_sitelib}/initial_setup/gui/*
+%{python3_sitelib}/initial_setup/gui
 
 %changelog
 * Mon Jul 12 2021 Martin Kolman <mkolman@redhat.com> - 0.3.93-1


### PR DESCRIPTION
Fix ownership of the /usr/lib/python<version>/site-packages/initial_setup/gui
directory so it does not stay behind if the initial-setup-gui is uninstalled.

According to the RPM documentation it should be enough to mention the
full path without an asterisk at the end to both own the directory as
well as to include all the containing files.

Resolves: rhbz#1812463