### PR TITLE
Use Anaconda DBus read-write properties

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -13,7 +13,7 @@ Release: 1%{?dist}
 Source0: %{name}-%{version}.tar.gz
 
 %define debug_package %{nil}
-%define anacondaver 36.7-1
+%define anacondaver 37.8-1
 
 License: GPLv2+
 BuildRequires: gettext

--- a/initial_setup/__init__.py
+++ b/initial_setup/__init__.py
@@ -251,7 +251,7 @@ class InitialSetup(object):
             # set the reconfig flag in kickstart so that
             # relevant spokes show up
             services_proxy = SERVICES.get_proxy()
-            services_proxy.SetSetupOnBoot(SETUP_ON_BOOT_RECONFIG)
+            services_proxy.SetupOnBoot = SETUP_ON_BOOT_RECONFIG
 
         # Record if groups, users or root password has been set before Initial Setup
         # has been started, so that we don't trample over existing configuration.
@@ -356,7 +356,7 @@ class InitialSetup(object):
             # to kickstart if neither /etc/reconfigSys or /.unconfigured
             # are present
             services_proxy = SERVICES.get_proxy()
-            services_proxy.SetSetupOnBoot(SETUP_ON_BOOT_DEFAULT)
+            services_proxy.SetupOnBoot = SETUP_ON_BOOT_DEFAULT
 
         # Write the kickstart data to file
         log.info("writing the Initial Setup kickstart file %s", OUTPUT_KICKSTART_PATH)


### PR DESCRIPTION
Anaconda is replacing `Set.*` methods with with read-write properties to clean
up the DBus API and simplify unit testing with mocked DBus objects.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/3789