### PR TITLE
Translate quit message

### DIFF
--- a/initial_setup/common.py
+++ b/initial_setup/common.py
@@ -100,12 +100,12 @@ def list_usable_consoles_for_tui():
 
 def get_quit_message():
     if eula_available():
-        return N_("Are you sure you want to quit the configuration process?\n"
-                  "You might end up with an unusable system if you do. Unless the "
-                  "License agreement is accepted, the system will be rebooted.")
+        return _("Are you sure you want to quit the configuration process?\n"
+                 "You might end up with an unusable system if you do. Unless the "
+                 "License agreement is accepted, the system will be rebooted.")
     else:
-        return N_("Are you sure you want to quit the configuration process?\n"
-                  "You might end up with unusable system if you do.")
+        return _("Are you sure you want to quit the configuration process?\n"
+                 "You might end up with unusable system if you do.")
 
 
 class LicensingCategory(SpokeCategory):


### PR DESCRIPTION
As far as I read commit logs, these messages are not intentionally untranslated.

Found by @miraclelinux and @almalinux.

Untranslated messages are displayed when clicking 終了 (quit) at initial setup EULA screen.

![image](https://github.com/rhinstaller/initial-setup/assets/941609/520dd57b-cdae-487d-8040-e017c9c47824)