### PR TITLE
Fix Anaconda module startup

### DIFF
--- a/data/10-initial-setup.conf
+++ b/data/10-initial-setup.conf
@@ -4,14 +4,23 @@
 
 [Anaconda]
 # List of enabled kickstart modules.
-kickstart_modules =
-     org.fedoraproject.Anaconda.Modules.Timezone
-     org.fedoraproject.Anaconda.Modules.Network
-     org.fedoraproject.Anaconda.Modules.Localization
-     org.fedoraproject.Anaconda.Modules.Security
-     org.fedoraproject.Anaconda.Modules.Users
-     org.fedoraproject.Anaconda.Modules.Services
+activatable_modules =
+    org.fedoraproject.Anaconda.Modules.Timezone
+    org.fedoraproject.Anaconda.Modules.Network
+    org.fedoraproject.Anaconda.Modules.Localization
+    org.fedoraproject.Anaconda.Modules.Security
+    org.fedoraproject.Anaconda.Modules.Users
+    org.fedoraproject.Anaconda.Modules.Services
 
+# Make sure modules that are not supported on installed
+# system are not run.
+forbidden_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
+    org.fedoraproject.Anaconda.Modules.Storage
+    org.fedoraproject.Anaconda.Modules.Payloads
+
+optional_modules =
+    org.fedoraproject.Anaconda.Addons.*
 
 [Installation System]
 # Type of the installation system.


### PR DESCRIPTION
Adjust Initial Setup to properly use the new Anaconda config file keys to configure which modules should be started and which not.

This should also fix an issue on real world ARM hardware, where Initial Setup in reconfig mode failed to start due to extra modules being started unexpectedly.

Resolves: rhbz#2241274