### PR TITLE
Allow and prefer running the graphical setup in wayland

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -45,8 +45,7 @@ Requires: gtk3
 Requires: anaconda-gui >= %{anacondaver}
 Requires: firstboot(gui-backend)
 Requires: %{name} = %{version}-%{release}
-# Consider changing this to a wayland backend, such as using weston
-Suggests: %{name}-gui-xorg
+Suggests: %{name}-gui-wayland-generic
 
 %description gui
 The initial-setup-gui package contains a graphical user interface for the
@@ -61,8 +60,22 @@ Requires: firstboot(windowmanager)
 
 Provides:  firstboot(gui-backend)
 Conflicts: firstboot(gui-backend)
+RemovePathPostfixes: .guixorg
 
 %description gui-xorg
+%{summary}.
+
+%package gui-wayland-generic
+Summary: Run the initial-setup GUI in Wayland
+Requires: %{name}-gui = %{version}-%{release}
+Requires: weston
+Requires: xorg-x11-server-Xwayland
+
+Provides:  firstboot(gui-backend)
+Conflicts: firstboot(gui-backend)
+RemovePathPostfixes: .guiweston
+
+%description gui-wayland-generic
 %{summary}.
 
 %prep
@@ -77,6 +90,9 @@ make
 %install
 rm -rf %{buildroot}
 make DESTDIR=%{buildroot} install
+
+# Remove the default link, provide subpackages for alternatives
+rm %{buildroot}%{_libexecdir}/%{name}/run-gui-backend
 
 %find_lang %{name}
 
@@ -116,8 +132,11 @@ rm -rf %{buildroot}
 %{python3_sitelib}/initial_setup/gui/
 
 %files gui-xorg
-%{_libexecdir}/%{name}/run-gui-backend
+%{_libexecdir}/%{name}/run-gui-backend.guixorg
 %{_libexecdir}/%{name}/firstboot-windowmanager
+
+%files gui-wayland-generic
+%{_libexecdir}/%{name}/run-gui-backend.guiweston
 
 %changelog
 * Mon Oct 09 2023 Martin Kolman <mkolman@redhat.com> - 0.3.98-1

--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -43,14 +43,27 @@ a series of steps that allows for easier configuration of the machine.
 Summary: Graphical user interface for the initial-setup utility
 Requires: gtk3
 Requires: anaconda-gui >= %{anacondaver}
-Requires: firstboot(windowmanager)
-Requires: xorg-x11-xinit
-Requires: xorg-x11-server-Xorg
+Requires: firstboot(gui-backend)
 Requires: %{name} = %{version}-%{release}
+# Consider changing this to a wayland backend, such as using weston
+Suggests: %{name}-gui-xorg
 
 %description gui
 The initial-setup-gui package contains a graphical user interface for the
 initial-setup utility.
+
+%package gui-xorg
+Summary: Run the initial-setup GUI in Xorg
+Requires: %{name}-gui = %{version}-%{release}
+Requires: xorg-x11-xinit
+Requires: xorg-x11-server-Xorg
+Requires: firstboot(windowmanager)
+
+Provides:  firstboot(gui-backend)
+Conflicts: firstboot(gui-backend)
+
+%description gui-xorg
+%{summary}.
 
 %prep
 %autosetup -p 1
@@ -85,7 +98,6 @@ rm -rf %{buildroot}
 %{python3_sitelib}/initial_setup*
 %exclude %{python3_sitelib}/initial_setup/gui
 %{_libexecdir}/%{name}/run-initial-setup
-%{_libexecdir}/%{name}/firstboot-windowmanager
 %{_libexecdir}/%{name}/initial-setup-text
 %{_libexecdir}/%{name}/reconfiguration-mode-enabled
 %{_unitdir}/initial-setup.service
@@ -102,6 +114,10 @@ rm -rf %{buildroot}
 %files gui
 %{_libexecdir}/%{name}/initial-setup-graphical
 %{python3_sitelib}/initial_setup/gui/
+
+%files gui-xorg
+%{_libexecdir}/%{name}/run-gui-backend
+%{_libexecdir}/%{name}/firstboot-windowmanager
 
 %changelog
 * Mon Oct 09 2023 Martin Kolman <mkolman@redhat.com> - 0.3.98-1

--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -121,6 +121,7 @@ rm -rf %{buildroot}
 %dir %{_sysconfdir}/%{name}
 %dir %{_sysconfdir}/%{name}/conf.d
 %config %{_sysconfdir}/%{name}/conf.d/*
+%{_sysconfdir}/pam.d/initial-setup
 
 %ifarch s390 s390x
 %{_sysconfdir}/profile.d/initial-setup.sh

--- a/pam/initial-setup
+++ b/pam/initial-setup
@@ -1,0 +1,8 @@
+#%PAM-1.0
+auth       sufficient  pam_permit.so
+account    sufficient  pam_permit.so
+password   sufficient  pam_permit.so
+session    required    pam_loginuid.so
+-session   optional    pam_keyinit.so revoke
+-session   optional    pam_limits.so
+session    required    pam_systemd.so

--- a/scripts/firstboot-windowmanager
+++ b/scripts/firstboot-windowmanager
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # This is the list of supported window manager binaries
-WMS=("gnome-kiosk" "metacity" "kwin_x11" "kwin" "xfwm4" "openbox" "marco")
+WMS=("gnome-kiosk" "metacity" "kwin_x11" "xfwm4" "openbox" "marco")
 
 run_gnome_kiosk()
 {

--- a/scripts/initial-setup-graphical
+++ b/scripts/initial-setup-graphical
@@ -4,6 +4,9 @@ import os
 
 from initial_setup import InitialSetup, InitialSetupError
 
+# Doesn't work with native Wayland yet
+os.environ["GDK_BACKEND"] = "x11"
+
 is_instance = InitialSetup(gui_mode=True)
 
 try:

--- a/scripts/run-gui-backend
+++ b/scripts/run-gui-backend
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+## Runs the GUI program from $@ in Xorg with one of the supported window managers
+
+WINDOWMANAGER_SCRIPT="/usr/libexec/initial-setup/firstboot-windowmanager"
+/bin/xinit ${WINDOWMANAGER_SCRIPT} $@ -- /bin/Xorg :9 -ac -nolisten tcp

--- a/scripts/run-gui-backend
+++ b/scripts/run-gui-backend
@@ -1,6 +1,1 @@
-#!/bin/sh
-
-## Runs the GUI program from $@ in Xorg with one of the supported window managers
-
-WINDOWMANAGER_SCRIPT="/usr/libexec/initial-setup/firstboot-windowmanager"
-/bin/xinit ${WINDOWMANAGER_SCRIPT} $@ -- /bin/Xorg :9 -ac -nolisten tcp
+run-gui-backend.guiweston

--- a/scripts/run-gui-backend.guiweston
+++ b/scripts/run-gui-backend.guiweston
@@ -18,7 +18,7 @@ EOF
 
 cat > ${RUN_SCRIPT} << EOF
 #!/bin/sh
-GDK_BACKEND=x11 $@
+$@
 echo $? > ${EXIT_CODE_SAVE}
 EOF
 

--- a/scripts/run-gui-backend.guiweston
+++ b/scripts/run-gui-backend.guiweston
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+## Runs the GUI program from $@ in Weston
+
+CONFIG_FILE=$(mktemp --suffix="-wl-weston-firstboot-ini")
+RUN_SCRIPT=$(mktemp --suffix="-wl-weston-firstboot-run")
+EXIT_CODE_SAVE=$(mktemp --suffix="-wl-weston-firstboot-exit")
+
+cat > ${CONFIG_FILE} << EOF
+[core]
+shell=kiosk
+xwayland=true
+
+[autolaunch]
+path=${RUN_SCRIPT}
+watch=true
+EOF
+
+cat > ${RUN_SCRIPT} << EOF
+#!/bin/sh
+GDK_BACKEND=x11 $@
+echo $? > ${EXIT_CODE_SAVE}
+EOF
+
+chmod +x ${RUN_SCRIPT}
+
+weston --config=${CONFIG_FILE} --socket=wl-firstboot-0
+exit_code=$(< ${EXIT_CODE_SAVE})
+
+rm ${CONFIG_FILE} ${RUN_SCRIPT} ${EXIT_CODE_SAVE}
+exit $exit_code

--- a/scripts/run-gui-backend.guixorg
+++ b/scripts/run-gui-backend.guixorg
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+## Runs the GUI program from $@ in Xorg with one of the supported window managers
+
+WINDOWMANAGER_SCRIPT="/usr/libexec/initial-setup/firstboot-windowmanager"
+/bin/xinit ${WINDOWMANAGER_SCRIPT} $@ -- /bin/Xorg :9 -ac -nolisten tcp

--- a/scripts/run-initial-setup
+++ b/scripts/run-initial-setup
@@ -16,20 +16,28 @@ if [ -f ${IS_GRAPHICAL} ]; then
     # users are not expecting a graphical interface do start in such case
     # and there might not even be any displays connected
     if [ "$CURRENT_DEFAULT_TARGET" == "$GRAPHICAL_TARGET" ]; then
+        export XDG_RUNTIME_DIR=$(mktemp --directory --suffix="-initial-setup-runtime-dir")
+        chmod 700 "$XDG_RUNTIME_DIR"
+
         echo "Starting Initial Setup GUI" | systemd-cat -t initial-setup -p 6
         ${START_GUI_COMMAND}
+        res=$?
+
+        rm -rf "$XDG_RUNTIME_DIR"
     else
         echo "Initial Setup GUI is installed, but default.target != graphical.target" | systemd-cat -t initial-setup -p 5
         echo "Starting Initial Setup TUI" | systemd-cat -t initial-setup -p 6
         ${IS_TEXT} --no-stdout-log
+        res=$?
     fi
 else
     echo "Starting Initial Setup TUI" | systemd-cat -t initial-setup -p 6
     ${IS_TEXT} --no-stdout-log
+    res=$?
 fi
 
 # check if the Initial Setup run was successful by looking at the return code
-if [ $? -eq 0 ]; then
+if [ $res -eq 0 ]; then
     echo "Initial Setup finished successfully, disabling" | systemd-cat -t initial-setup -p 6
     systemctl -q is-enabled $IS_UNIT && systemctl disable $IS_UNIT
     echo "Initial Setup has been disabled" | systemd-cat -t initial-setup -p 6

--- a/scripts/run-initial-setup
+++ b/scripts/run-initial-setup
@@ -8,9 +8,7 @@ IS_UNIT=initial-setup.service
 GRAPHICAL_TARGET=/usr/lib/systemd/system/graphical.target
 CURRENT_DEFAULT_TARGET=$(readlink -e /etc/systemd/system/default.target)
 
-WINDOWMANAGER_SCRIPT="/usr/libexec/initial-setup/firstboot-windowmanager"
-
-START_GUI_COMMAND="/bin/xinit ${WINDOWMANAGER_SCRIPT} ${IS_GRAPHICAL} --no-stdout-log -- /bin/Xorg :9 -ac -nolisten tcp"
+START_GUI_COMMAND="/usr/libexec/initial-setup/run-gui-backend ${IS_GRAPHICAL} --no-stdout-log"
 
 # check if graphical Initial Setup is installed
 if [ -f ${IS_GRAPHICAL} ]; then

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ data_files = [('/usr/lib/systemd/system', glob('systemd/*.service')),
               ('/usr/libexec/initial-setup/',
               ["scripts/run-initial-setup", "scripts/firstboot-windowmanager",
                "scripts/initial-setup-text", "scripts/initial-setup-graphical",
-               "scripts/run-gui-backend",
+               "scripts/run-gui-backend.guixorg", "scripts/run-gui-backend.guiweston",
+               "scripts/run-gui-backend",  # symlink to the default backend
                "scripts/reconfiguration-mode-enabled"]),
               ('/usr/share/doc/initial-setup/', ["ChangeLog"])]
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ data_files = [('/usr/lib/systemd/system', glob('systemd/*.service')),
               ('/usr/libexec/initial-setup/',
               ["scripts/run-initial-setup", "scripts/firstboot-windowmanager",
                "scripts/initial-setup-text", "scripts/initial-setup-graphical",
+               "scripts/run-gui-backend",
                "scripts/reconfiguration-mode-enabled"]),
               ('/usr/share/doc/initial-setup/', ["ChangeLog"])]
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ from setuptools import setup, find_packages
 
 data_files = [('/usr/lib/systemd/system', glob('systemd/*.service')),
               ('/etc/initial-setup/conf.d', glob('data/*.conf')),
+              ('/etc/pam.d', glob('pam/*')),
               ('/usr/libexec/initial-setup/',
               ["scripts/run-initial-setup", "scripts/firstboot-windowmanager",
                "scripts/initial-setup-text", "scripts/initial-setup-graphical",

--- a/systemd/initial-setup.service
+++ b/systemd/initial-setup.service
@@ -2,6 +2,7 @@
 Description=Initial Setup configuration program
 After=livesys.service plymouth-quit-wait.service
 After=systemd-vconsole-setup.service
+After=systemd-user-sessions.service
 # getty-pre.target is a pasive target, we need to request it before we can use it
 Wants=getty-pre.target
 # prevent getty from running on any consoles before we are done
@@ -23,6 +24,15 @@ ExecStart=/usr/libexec/initial-setup/run-initial-setup
 ExecStartPost=/bin/kill -SIGRTMIN+20 1
 TimeoutSec=0
 RemainAfterExit=no
+
+# setup session
+User=root
+Group=root
+PAMName=initial-setup
+TTYPath=/dev/tty7
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes
 
 [Install]
 WantedBy=graphical.target


### PR DESCRIPTION
Hi!
The initial-setup was configured to always run Xorg and an x11 window manager.
We're dropping kwin_x11 from Fedora KDE in Fedora 40 so there won't be any x11 window manager nor Xorg preloaded.

This PR defines the interface for a generic graphic server to run the firstboot ui as a `/usr/libexec/initial-setup/run-gui-backend` program taking as parameters the firstboot binary and arguments.
We implement a generic wayland server with weston, and use it by default.

The desktops can ship the configuration for their preferred compositor with a package providing their runner program at `/usr/libexec/initial-setup/run-gui-backend`, and
```
Provides:  firstboot(gui-backend)
Conflicts: firstboot(gui-backend)
```

Xorg+some window manager is still available as an option via `initial-setup-gui-xorg` that implements the same interface.