### PR TITLE
Update the systemd service, to use kmscon instead of fbcon

### DIFF
--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -35,6 +35,7 @@ Requires: anaconda-tui >= %{anacondaver}
 Requires: libxkbcommon
 Requires: python3-simpleline >= 1.4
 Requires: systemd >= 235
+Requires: kmscon >= 10.0.1
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd

--- a/initial_setup/tui/tui.py
+++ b/initial_setup/tui/tui.py
@@ -27,7 +27,7 @@ class MultipleTTYHandler(object):
     the Initial Setup stdin.
     """
 
-    def __init__(self, tui_stdout_fd, tui_stdin_fd):
+    def __init__(self, tui_stdout_fd, tui_stdin_fd, console):
         # create file objects for the TUI stdout and stdin fds
         self._tui_stdout_fd = tui_stdout_fd
         self._tui_stdout = os.fdopen(tui_stdout_fd, "r")
@@ -43,6 +43,8 @@ class MultipleTTYHandler(object):
         self._active_console_in = None
         self._active_console_out = None
 
+        self._origin_console = console
+
         self._console_read_fos = {}
         self._console_write_fos = []
         self._open_all_consoles()
@@ -55,10 +57,12 @@ class MultipleTTYHandler(object):
         """Open all consoles suitable for running the Initial Setup TUI."""
         console_write_fos = {}
         console_read_fos = {}
-        console_paths = (os.path.join("/dev", c) for c in list_usable_consoles_for_tui())
+        console_paths = [os.path.join("/dev", c) for c in list_usable_consoles_for_tui()]
+        if self._origin_console:
+            console_paths.append(self._origin_console)
         usable_console_paths = []
         unusable_console_paths = []
-        for console_path in console_paths:
+        for console_path in set(console_paths):
             try:
                 write_fo = open(console_path, "w")
                 read_fo = open(console_path, "r")
@@ -268,6 +272,11 @@ class InitialSetupTextUserInterface(TextUserInterface):
         # start the multi TTY handler and just run in the single
         # local console.
         if self._use_multi_tty_handler:
+            # save current console
+            current_console = None
+            if os.isatty(sys.stdout.fileno()):
+                current_console = os.ttyname(sys.stdout.fileno())
+
             # redirect stdin and stdout to custom pipes
 
             # stdin
@@ -281,7 +290,8 @@ class InitialSetupTextUserInterface(TextUserInterface):
 
             # instantiate and start the multi TTY handler
             self.multi_tty_handler = MultipleTTYHandler(tui_stdin_fd=tui_stdin_fd,
-                                                        tui_stdout_fd=tui_stdout_fd)
+                                                        tui_stdout_fd=tui_stdout_fd,
+                                                        console=current_console)
             # start the multi-tty handler
             thread_manager.add_thread(
                 name="initial_setup_multi_tty_thread",

--- a/systemd/initial-setup.service
+++ b/systemd/initial-setup.service
@@ -15,13 +15,10 @@ ConditionKernelCommandLine=!rd.live.image
 Type=oneshot
 TimeoutSec=0
 RemainAfterExit=yes
-# tell systemd to stop logging to the console, to prevent it's messages
-# with interfering with the Initial Setup TUI potentially running there
-ExecStartPre=/bin/kill -SIGRTMIN+21 1
 ExecStartPre=-/bin/plymouth quit
-ExecStart=/usr/libexec/initial-setup/run-initial-setup
-# re-enable systemd console logging once Initial Setup is done
-ExecStartPost=/bin/kill -SIGRTMIN+20 1
+ExecStart=/usr/bin/kmscon --vt 7 --no-issue --oneshot --login /usr/libexec/initial-setup/run-initial-setup
+# Return to tty 1
+ExecStartPost=chvt 1
 TimeoutSec=0
 RemainAfterExit=no
 


### PR DESCRIPTION
On Fedora rawhide, kmscon is now the default, and the initial setup script is hidden behind the kmscon console.

Fix #160 

It's a draft, I wasn't able to test it yet.