### PR TITLE
Fix initial-setup GUI failing to start on ARM due to weston input device access

### DIFF
--- a/scripts/run-gui-backend.guiweston
+++ b/scripts/run-gui-backend.guiweston
@@ -37,7 +37,7 @@ secondary_cards=$(echo "$cards"|
                   tail -n +2|
                   xargs printf "%s,")
 
-weston --config=${CONFIG_FILE} --socket=wl-firstboot-0 --drm-device="$primary_card" --additional-devices="$secondary_cards"
+LIBSEAT_BACKEND=noop weston --config=${CONFIG_FILE} --socket=wl-firstboot-0 --drm-device="$primary_card" --additional-devices="$secondary_cards"
 exit_code=$(< ${EXIT_CODE_SAVE})
 
 rm ${CONFIG_FILE} ${RUN_SCRIPT} ${EXIT_CODE_SAVE}


### PR DESCRIPTION
PR #156 fixed the GUI startup on x86 by adding VT switching and multi-GPU enumeration, but the fix is insufficient on ARM (e.g., Raspberry Pi). On ARM, weston starts, gets "session control granted" from libseat's logind backend, but then rejects all input devices with "not using input device" and crashes with SIGSEGV in Mesa's teardown path.

Root cause: `initial-setup.service` runs as a systemd service (User=root). When `pam_systemd.so` creates a logind session, it gets `class=user-early type=tty` with no seat assignment. This is by design -- logind does not assign seats to sessions created by systemd services. Without a seat, libseat's logind backend cannot hand over input devices to weston, and weston's libinput rejects them all.

Fix: Set `LIBSEAT_BACKEND=noop` before the weston invocation. The noop backend bypasses logind session management entirely. Since initial-setup runs as root, weston can open DRM and input devices directly without needing logind's device handoff.

This fix is safe to apply universally alongside PR #156's VT switching and multi-GPU changes. The noop backend is appropriate here because initial-setup is a one-shot root process during first boot -- multi-seat and unprivileged access scenarios do not apply.

Tested on Raspberry Pi 4 Model B, Fedora 45 Xfce aarch64, kernel 7.2.0-rc6, weston 15.0.1, Mesa 26.2.0.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2358688

Assisted-By: Claude Opus 4.6