### PR TITLE
Fix s390 build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,5 @@ recursive-include initial_setup *.py *.glade
 recursive-exclude modules *.pyc *.pyo
 include data/10-initial-setup.conf
 include pam/initial-setup
+include scripts/s390/initial-setup.csh
+include scripts/s390/initial-setup.sh

--- a/initial-setup.spec
+++ b/initial-setup.spec
@@ -157,6 +157,12 @@ install -m 644 data/10-initial-setup.conf %{buildroot}%{_sysconfdir}/%{name}/con
 install -d %{buildroot}%{_sysconfdir}/pam.d
 install -m 644 pam/initial-setup %{buildroot}%{_sysconfdir}/pam.d/
 
+%ifarch s390 s390x
+install -d %{buildroot}%{_sysconfdir}/profile.d
+install -m 644 scripts/s390/initial-setup.sh %{buildroot}%{_sysconfdir}/profile.d/
+install -m 644 scripts/s390/initial-setup.csh %{buildroot}%{_sysconfdir}/profile.d/
+%endif
+
 # Remove the default link, provide subpackages for alternatives
 rm %{buildroot}%{_libexecdir}/%{name}/run-gui-backend
 


### PR DESCRIPTION
Looks like some of the weird s390 shell profile files were not properly declared, causing the s390 build to fail.