### PR TITLE
Fix card enumeration for weston

### DIFF
--- a/scripts/run-gui-backend.guiweston
+++ b/scripts/run-gui-backend.guiweston
@@ -31,14 +31,42 @@ if [ -n "$XDG_VTNR" ]; then
     chvt "${XDG_VTNR}"
 fi
 
-cards=$(ls -d /sys/class/drm/card*| grep -v -- -| cut -d / -f 5)
-primary_card=$(echo "$cards" | head -1 )
-secondary_cards=$(echo "$cards"|
-                  tail -n +2|
-                  xargs printf "%s,")
+# Wait for udev to finish processing device events so all DRM drivers
+# are loaded before we enumerate cards. Without this, late-loading
+# drivers (e.g., vc4 on RPi4) may not have registered their DRM device
+# yet, causing us to pick a non-KMS card like simpledrm.
+udevadm settle --timeout=30
 
-LIBSEAT_BACKEND=noop weston --config=${CONFIG_FILE} --socket=wl-firstboot-0 --drm-device="$primary_card" --additional-devices="$secondary_cards"
+# Find the primary KMS-capable card by checking for connector entries
+# (e.g., card2-HDMI-A-1). Render-only GPUs (v3d) and simple framebuffers
+# (simpledrm) don't have connectors and can't be used as primary display.
+cards=$(ls -d /sys/class/drm/card[0-9]* 2>/dev/null | grep -v -- - | cut -d / -f 5)
+primary_card=
+for card in $cards; do
+    if ls /sys/class/drm/${card}-* >/dev/null 2>&1; then
+        primary_card=$card
+        break
+    fi
+done
+
+secondary_cards=
+if [ -n "$primary_card" ]; then
+    for card in $cards; do
+        if [ "$card" != "$primary_card" ]; then
+            secondary_cards="${secondary_cards:+${secondary_cards},}${card}"
+        fi
+    done
+fi
+
+if [ -z "$primary_card" ]; then
+    echo "No KMS-capable DRM device found" >&2
+    echo 1 > ${EXIT_CODE_SAVE}
+else
+    LIBSEAT_BACKEND=noop weston --config=${CONFIG_FILE} --socket=wl-firstboot-0 --drm-device="$primary_card" --additional-devices="$secondary_cards"
+fi
+
 exit_code=$(< ${EXIT_CODE_SAVE})
+exit_code=${exit_code:-1}
 
 rm ${CONFIG_FILE} ${RUN_SCRIPT} ${EXIT_CODE_SAVE}
 if [ -n "$original_vt" ]; then

--- a/scripts/run-gui-backend.guiweston
+++ b/scripts/run-gui-backend.guiweston
@@ -31,22 +31,23 @@ if [ -n "$XDG_VTNR" ]; then
     chvt "${XDG_VTNR}"
 fi
 
-# Wait for udev to finish processing device events so all DRM drivers
-# are loaded before we enumerate cards. Without this, late-loading
-# drivers (e.g., vc4 on RPi4) may not have registered their DRM device
-# yet, causing us to pick a non-KMS card like simpledrm.
-udevadm settle --timeout=30
+# Find the primary KMS-capable card by looking for connectors with a
+# known display type. Cards with only "Unknown" connectors (simpledrm)
+# or "Writeback" connectors are not usable as primary display devices.
 
-# Find the primary KMS-capable card by checking for connector entries
-# (e.g., card2-HDMI-A-1). Render-only GPUs (v3d) and simple framebuffers
-# (simpledrm) don't have connectors and can't be used as primary display.
-cards=$(ls -d /sys/class/drm/card[0-9]* 2>/dev/null | grep -v -- - | cut -d / -f 5)
+# Poll up to 10 seconds for usable card
 primary_card=
-for card in $cards; do
-    if ls /sys/class/drm/${card}-* >/dev/null 2>&1; then
-        primary_card=$card
-        break
-    fi
+attempt=0
+while [ $attempt -lt 10 ]; do
+    cards=$(ls -d /sys/class/drm/card[0-9]* 2>/dev/null | grep -v -- - | cut -d / -f 5)
+    for card in $cards; do
+        if ls /sys/class/drm/${card}-* >/dev/null 2>&1 | grep -qvE "Unknown|Writeback"; then
+            primary_card=$card
+            break 2
+        fi
+    done
+    attempt=$((attempt + 1))
+    sleep 1
 done
 
 secondary_cards=
@@ -59,14 +60,22 @@ if [ -n "$primary_card" ]; then
 fi
 
 if [ -z "$primary_card" ]; then
-    echo "No KMS-capable DRM device found" >&2
-    echo 1 > ${EXIT_CODE_SAVE}
+    connectors=$(ls -d /sys/class/drm/card[0-9]*-* 2>/dev/null | grep -v -- - | cut -d / -f 5 | tr '\n' ' ')
+    echo "run-gui-backend: no KMS-capable DRM device found" \
+         "(cards: ${cards:-none}, connectors: ${connectors:-none})" |
+        systemd-cat -t run-gui-backend -p 3
+    weston_exit_code=1
 else
+    echo "run-gui-backend: using $primary_card" |
+        systemd-cat -t run-gui-backend -p 6
     LIBSEAT_BACKEND=noop weston --config=${CONFIG_FILE} --socket=wl-firstboot-0 --drm-device="$primary_card" --additional-devices="$secondary_cards"
+    weston_exit_code=$?
 fi
 
-exit_code=$(< ${EXIT_CODE_SAVE})
-exit_code=${exit_code:-1}
+# The autolaunch script saves the initial-setup exit code to EXIT_CODE_SAVE file.
+# If the file is empty, fall back to weston's own exit code
+exit_code=$(cat "${EXIT_CODE_SAVE}")
+exit_code=${exit_code:-$weston_exit_code}
 
 rm ${CONFIG_FILE} ${RUN_SCRIPT} ${EXIT_CODE_SAVE}
 if [ -n "$original_vt" ]; then

--- a/scripts/run-gui-backend.guiweston
+++ b/scripts/run-gui-backend.guiweston
@@ -26,16 +26,21 @@ chmod +x ${RUN_SCRIPT}
 
 original_vt=
 if [ -n "$XDG_VTNR" ]; then
-    original_vt=$(fgconsole)
-    # change to VT on which we run to get access to devices
-    chvt "${XDG_VTNR}"
+    original_vt=$(fgconsole 2>/dev/null)
+    # When running inside a terminal emulator that holds DRM master (e.g.,
+    # kmscon on tty7), we must switch to a different VT to force it to
+    # release DRM master so Weston can acquire it.
+    weston_vt=$((XDG_VTNR + 1))
+    chvt "$weston_vt"
 fi
 
 # Find the primary KMS-capable card by looking for connectors with a
 # known display type. Cards with only "Unknown" connectors (simpledrm)
 # or "Writeback" connectors are not usable as primary display devices.
 
-# Poll up to 10 seconds for usable card
+# DRM drivers may still be loading at this point (e.g. vc4 on RPi4 registers
+# several seconds after simpledrm and v3d), so poll up to 10 seconds for
+# usable card to appear.
 primary_card=
 attempt=0
 while [ $attempt -lt 10 ]; do


### PR DESCRIPTION
- fix primary card detection in cases when KMS-capable card is not the first in the list
- fix race condition where sometimes not all drivers were loaded during card enumeration
- fix incorrect exit code if weston fails

Please see for details: https://bugzilla.redhat.com/show_bug.cgi?id=2526278

Assisted-By: Claude Opus 4.6